### PR TITLE
Use S3 object existence check

### DIFF
--- a/timeseries-lambda/src/main/java/com/leonarduk/aws/S3DataStore.java
+++ b/timeseries-lambda/src/main/java/com/leonarduk/aws/S3DataStore.java
@@ -18,6 +18,14 @@ import java.io.FileReader;
 import java.io.IOException;
 import java.util.List;
 
+/**
+ * Persist {@link StockV1} data in an S3 bucket.
+ * <p>
+ * The {@link #contains(StockV1)} method checks for the presence of the
+ * corresponding object in the configured S3 bucket and returns {@code true}
+ * only when that object exists.
+ * </p>
+ */
 @Slf4j
 public class S3DataStore extends AbstractCsvStockFeed implements DataStore {
 
@@ -50,7 +58,7 @@ public class S3DataStore extends AbstractCsvStockFeed implements DataStore {
 
     @Override
     public boolean contains(StockV1 stock) {
-        return s3.doesBucketExistV2(getS3Filepath(stock.getInstrument()));
+        return s3.doesObjectExist(bucketName, getS3Filepath(stock.getInstrument()));
     }
 
     @Override

--- a/timeseries-lambda/src/test/java/com/leonarduk/aws/S3DataStoreTest.java
+++ b/timeseries-lambda/src/test/java/com/leonarduk/aws/S3DataStoreTest.java
@@ -1,0 +1,52 @@
+package com.leonarduk.aws;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.leonarduk.finance.stockfeed.Instrument;
+import com.leonarduk.finance.stockfeed.feed.yahoofinance.StockV1;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Proxy;
+
+class S3DataStoreTest {
+
+    private S3DataStore createStore(boolean objectExists, Instrument instrument) throws Exception {
+        S3DataStore store = new S3DataStore("bucket", "folder", "eu-west-1");
+        AmazonS3 mockS3 = (AmazonS3) Proxy.newProxyInstance(
+                AmazonS3.class.getClassLoader(),
+                new Class[]{AmazonS3.class},
+                (proxy, method, args) -> {
+                    if (method.getName().equals("doesObjectExist")) {
+                        String bucket = (String) args[0];
+                        String key = (String) args[1];
+                        boolean matches = bucket.equals("bucket") && key.equals("folder/" + instrument.code() + ".csv");
+                        return objectExists && matches;
+                    }
+                    if (method.getReturnType().equals(boolean.class)) {
+                        return false;
+                    }
+                    return null;
+                });
+        Field field = S3DataStore.class.getDeclaredField("s3");
+        field.setAccessible(true);
+        field.set(store, mockS3);
+        return store;
+    }
+
+    @Test
+    void containsReturnsTrueWhenObjectExists() throws Exception {
+        Instrument instrument = Instrument.fromString("TEST", "L", "EQUITY", "GBP");
+        StockV1 stock = new StockV1(instrument);
+        S3DataStore store = createStore(true, instrument);
+        Assertions.assertTrue(store.contains(stock));
+    }
+
+    @Test
+    void containsReturnsFalseWhenObjectMissing() throws Exception {
+        Instrument instrument = Instrument.fromString("TEST", "L", "EQUITY", "GBP");
+        StockV1 stock = new StockV1(instrument);
+        S3DataStore store = createStore(false, instrument);
+        Assertions.assertFalse(store.contains(stock));
+    }
+}


### PR DESCRIPTION
## Summary
- document that `contains` checks S3 for object existence and returns true only when object is found
- replace bucket existence check with `doesObjectExist`
- add unit test verifying `contains` behavior

## Testing
- `mvn -f timeseries-lambda/pom.xml test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 could not be resolved: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6897db8919388327a4a06fc6f5c55de9