### PR TITLE
Remove redundant dependencies from Spring Boot server POM

### DIFF
--- a/timeseries-spring-boot-server/pom.xml
+++ b/timeseries-spring-boot-server/pom.xml
@@ -31,31 +31,9 @@
 		<jahoo.finance.version>3.15.0</jahoo.finance.version>
 	</properties>
 
-	<repositories>
-
-		<repository>
-			<id>sonatype</id>
-			<url>https://oss.sonatype.org/content/groups/public</url>
-		</repository>
-		<repository>
-			<id>central.maven.org</id>
-			<url>http://central.maven.org/maven2/</url>
-		</repository>
-	</repositories>
+        <!-- Repositories removed; rely on Maven Central defaults -->
 
 	<dependencies>
-		<!-- https://mvnrepository.com/artifact/org.apache.xmlgraphics/batik-transcoder -->
-		<dependency>
-			<groupId>org.apache.xmlgraphics</groupId>
-			<artifactId>batik-transcoder</artifactId>
-			<version>1.17</version>
-		</dependency>
-		<!-- https://mvnrepository.com/artifact/org.apache.xmlgraphics/batik-codec -->
-		<dependency>
-			<groupId>org.apache.xmlgraphics</groupId>
-			<artifactId>batik-codec</artifactId>
-			<version>1.11</version>
-		</dependency>
 
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -80,49 +58,13 @@
             <version>0.1.3</version>
             <scope>compile</scope>
         </dependency>
-		<!-- ta4j -->
-		<dependency>
-			<groupId>org.ta4j</groupId>
-			<artifactId>ta4j-core</artifactId>
-			<version>0.12</version>
-		</dependency>
-		<dependency>
-			<groupId>au.com.bytecode</groupId>
-			<artifactId>opencsv</artifactId>
-			<version>2.4</version>
-		</dependency>
-
-		<!-- google finance -->
-		<dependency>
-			<groupId>com.github.kevinsawicki</groupId>
-			<artifactId>http-request</artifactId>
-			<version>5.4</version>
-		</dependency>
-
-		<!-- test -->
-		<dependency>
-			<groupId>com.google.code.gson</groupId>
-			<artifactId>gson</artifactId>
-			<version>2.7</version>
-		</dependency>
 		<dependency>
 			<groupId>org.jacoco</groupId>
 			<artifactId>jacoco-maven-plugin</artifactId>
 			<version>${jacoco.version}</version>
 			<type>maven-plugin</type>
 		</dependency>
-        <!-- https://mvnrepository.com/artifact/commons-io/commons-io -->
-        <dependency>
-            <groupId>commons-io</groupId>
-            <artifactId>commons-io</artifactId>
-            <version>2.16.1</version>
-        </dependency>
 
-        <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-web</artifactId>
-            <scope>compile</scope>
-        </dependency>
 
         <!-- SpringDoc OpenAPI UI -->
         <dependency>


### PR DESCRIPTION
## Summary
- prune unused dependencies from the `timeseries-spring-boot-server` module
- rely on Maven Central by removing outdated custom repositories

## Testing
- `mvn package` *(fails: Non-resolvable parent POM for com.leonarduk:timeseries-spring-boot-server: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689cad1098ec8327a268aab44c1fe3ac