### PR TITLE
chore: update lambda dependencies

### DIFF
--- a/timeseries-lambda/pom.xml
+++ b/timeseries-lambda/pom.xml
@@ -39,7 +39,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-lambda-java-runtime-interface-client</artifactId>
-            <version>2.8.1</version>
+            <version>2.8.3</version>
         </dependency>
 
         <dependency>
@@ -57,24 +57,24 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
-            <version>${junit5.version}</version>
+            <version>5.13.0-M3</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-lambda-java-events</artifactId>
-            <version>3.16.0</version>
+            <version>3.16.1</version>
         </dependency>
 
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-java-sdk-core</artifactId>
-            <version>1.12.787</version>
+            <version>1.12.788</version>
         </dependency>
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-java-sdk-s3</artifactId>
-            <version>1.12.787</version>
+            <version>1.12.788</version>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/org.projectlombok/lombok -->
@@ -88,7 +88,7 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>32.0.0-jre</version>
+            <version>33.4.8-jre</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
## Summary
- bump Lambda runtime interface client and events libs
- update AWS SDK core/S3, Guava, and JUnit versions

## Testing
- `pre-commit run --files timeseries-lambda/pom.xml`
- `mvn -q -pl timeseries-lambda test` *(fails: Non-resolvable parent POM for com.leonarduk:timeseries-spring-boot-server:0.1.1)*

------
https://chatgpt.com/codex/tasks/task_e_689cad0fb150832789aadd41da6b1795