### PR TITLE
chore: update server dependencies

### DIFF
--- a/timeseries-spring-boot-server/pom.xml
+++ b/timeseries-spring-boot-server/pom.xml
@@ -1,13 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.3.0</version>
+        <version>3.5.3</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
 
@@ -27,7 +25,7 @@
 		<rest.assured.version>2.3.3</rest.assured.version>
 		<maven.compiler.source>21</maven.compiler.source>
 		<maven.compiler.target>21</maven.compiler.target>
-		<jacoco.version>0.8.4</jacoco.version>
+		<jacoco.version>0.8.13</jacoco.version>
 		<jahoo.finance.version>3.15.0</jahoo.finance.version>
 	</properties>
 
@@ -48,13 +46,13 @@
 		<dependency>
 			<groupId>org.apache.xmlgraphics</groupId>
 			<artifactId>batik-transcoder</artifactId>
-			<version>1.17</version>
+			<version>1.19</version>
 		</dependency>
 		<!-- https://mvnrepository.com/artifact/org.apache.xmlgraphics/batik-codec -->
 		<dependency>
 			<groupId>org.apache.xmlgraphics</groupId>
 			<artifactId>batik-codec</artifactId>
-			<version>1.11</version>
+			<version>1.19</version>
 		</dependency>
 
 		<dependency>
@@ -64,7 +62,7 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.18.36</version>
+            <version>1.18.38</version>
             <scope>provided</scope>
         </dependency>
 
@@ -86,25 +84,13 @@
 			<artifactId>ta4j-core</artifactId>
 			<version>0.12</version>
 		</dependency>
-		<dependency>
-			<groupId>au.com.bytecode</groupId>
-			<artifactId>opencsv</artifactId>
-			<version>2.4</version>
-		</dependency>
+		
 
 		<!-- google finance -->
-		<dependency>
-			<groupId>com.github.kevinsawicki</groupId>
-			<artifactId>http-request</artifactId>
-			<version>5.4</version>
-		</dependency>
+		
 
 		<!-- test -->
-		<dependency>
-			<groupId>com.google.code.gson</groupId>
-			<artifactId>gson</artifactId>
-			<version>2.7</version>
-		</dependency>
+		
 		<dependency>
 			<groupId>org.jacoco</groupId>
 			<artifactId>jacoco-maven-plugin</artifactId>
@@ -128,7 +114,7 @@
         <dependency>
             <groupId>org.springdoc</groupId>
             <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
-            <version>2.3.0</version>
+            <version>2.8.6</version>
         </dependency>
 
     </dependencies>


### PR DESCRIPTION
## Summary
- upgrade Spring Boot parent, Lombok, JaCoCo, Springdoc OpenAPI, and Apache Batik versions in server module
- remove unused http-request, Gson, and OpenCSV dependencies

## Testing
- `mvn clean package` *(fails: Non-resolvable parent POM org.springframework.boot:spring-boot-starter-parent:3.5.3)*

------
https://chatgpt.com/codex/tasks/task_e_689cad11a55c8327b65a542f1b62cac0