### PR TITLE
chore: remove unused timeseries dependencies

### DIFF
--- a/timeseries-sources/pom.xml
+++ b/timeseries-sources/pom.xml
@@ -19,25 +19,12 @@
         <properties>
                 <aws-java-sdk-bom.version>1.12.738</aws-java-sdk-bom.version>
                 <start-class>com.leonarduk.finance.springboot.App</start-class>
-                <jakarta.persistence.version>2.2.3</jakarta.persistence.version>
                 <org.seleniumhq.selenium.version>4.13.0</org.seleniumhq.selenium.version>
                 <org.junit.jupiter.version>5.9.0</org.junit.jupiter.version>
-                <org.jfree.version>3.4.4</org.jfree.version>
-                <org.apache.xmlgraphics.version>1.19</org.apache.xmlgraphics.version>
                 <alphavantage4j.version>1.5.0</alphavantage4j.version>
                 <yahoofinanceapi.version>3.17.0</yahoofinanceapi.version>
         </properties>
 
-	<repositories>
-		<repository>
-			<id>sonatype</id>
-			<url>https://oss.sonatype.org/content/groups/public</url>
-		</repository>
-		<repository>
-			<id>central.maven.org</id>
-			<url>http://central.maven.org/maven2/</url>
-		</repository>
-	</repositories>
         <dependencyManagement>
                 <dependencies>
                         <dependency>
@@ -113,36 +100,6 @@
 			<version>${org.apache.commons.version}</version>
 		</dependency>
 		<dependency>
-			<groupId>javax.xml.bind</groupId>
-			<artifactId>jaxb-api</artifactId>
-			<version>${javax.xml.bind.version}</version>
-		</dependency>
-		<dependency>
-			<groupId>com.sun.xml.bind</groupId>
-			<artifactId>jaxb-core</artifactId>
-			<version>4.0.5</version>
-		</dependency>
-		<dependency>
-			<groupId>com.sun.xml.bind</groupId>
-			<artifactId>jaxb-impl</artifactId>
-			<version>4.0.5</version>
-		</dependency>
-		<dependency>
-			<groupId>javax.activation</groupId>
-			<artifactId>activation</artifactId>
-			<version>1.1.1</version>
-		</dependency>
-		<dependency>
-			<groupId>com.h2database</groupId>
-			<artifactId>h2</artifactId>
-			<version>2.3.232</version>
-		</dependency>
-		<dependency>
-			<groupId>org.bgee.log4jdbc-log4j2</groupId>
-			<artifactId>log4jdbc-log4j2-jdbc4.1</artifactId>
-			<version>${log4jdbc.log4j2.version}</version>
-		</dependency>
-		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-api</artifactId>
 			<version>${org.slf4j.version}</version>
@@ -158,21 +115,6 @@
 					<artifactId>slf4j-api</artifactId>
 				</exclusion>
 			</exclusions>
-		</dependency>
-		<dependency>
-			<groupId>au.com.bytecode</groupId>
-			<artifactId>opencsv</artifactId>
-			<version>2.4</version>
-		</dependency>
-		<dependency>
-			<groupId>org.jfree</groupId>
-			<artifactId>jfreechart</artifactId>
-			<version>1.5.6</version>
-		</dependency>
-		<dependency>
-			<groupId>org.jfree</groupId>
-			<artifactId>jfreesvg</artifactId>
-			<version>${org.jfree.version}</version>
 		</dependency>
 		<!-- google finance -->
 		<dependency>
@@ -204,29 +146,12 @@
 			<version>${jacoco.version}</version>
 			<type>maven-plugin</type>
 		</dependency>
-        <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-web</artifactId>
-            <version>6.2.8</version>
-            <scope>compile</scope>
-        </dependency>
-		<dependency>
-			<groupId>jakarta.persistence</groupId>
-			<artifactId>jakarta.persistence-api</artifactId>
-			<version>${jakarta.persistence.version}</version>
-		</dependency>
-		<dependency>
-			<groupId>org.junit.jupiter</groupId>
-			<artifactId>junit-jupiter</artifactId>
-			<version>${org.junit.jupiter.version}</version>
-			<scope>test</scope>
-		</dependency>
-        <dependency>
-            <groupId>org.apache.xmlgraphics</groupId>
-            <artifactId>batik-transcoder</artifactId>
-            <version>${org.apache.xmlgraphics.version}</version>
-            <scope>compile</scope>
-        </dependency>
+                <dependency>
+                        <groupId>org.junit.jupiter</groupId>
+                        <artifactId>junit-jupiter</artifactId>
+                        <version>${org.junit.jupiter.version}</version>
+                        <scope>test</scope>
+                </dependency>
     </dependencies>
 	<build>
 		<plugins>


### PR DESCRIPTION
## Summary
- prune unused libraries from `timeseries-sources` module

## Testing
- `mvn test` *(fails: Non-resolvable import POM: com.amazonaws:aws-java-sdk-bom:1.12.738, network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689cad0b12c08327bd74b3702710ae0e