### PR TITLE
Switch to BarSeries API in stockfeed utilities

### DIFF
--- a/timeseries-sources/sources-stockfeed/src/main/java/com/leonarduk/finance/stockfeed/datatransformation/interpolation/AbstractLineInterpolator.java
+++ b/timeseries-sources/sources-stockfeed/src/main/java/com/leonarduk/finance/stockfeed/datatransformation/interpolation/AbstractLineInterpolator.java
@@ -5,7 +5,7 @@ import com.leonarduk.finance.stockfeed.feed.ExtendedHistoricalQuoteTimeSeries;
 import com.leonarduk.finance.utils.DateUtils;
 import com.leonarduk.finance.utils.TimeseriesUtils;
 import org.ta4j.core.Bar;
-import org.ta4j.core.TimeSeries;
+import org.ta4j.core.BarSeries;
 
 import java.io.IOException;
 import java.time.LocalDate;
@@ -55,7 +55,7 @@ public abstract class AbstractLineInterpolator implements TimeSeriesInterpolator
     }
 
     @Override
-    public TimeSeries interpolate(final TimeSeries timeseries) {
+    public BarSeries interpolate(final BarSeries timeseries) {
         if (timeseries.getEndIndex() < 0) {
             return timeseries;
         }

--- a/timeseries-sources/sources-stockfeed/src/main/java/com/leonarduk/finance/stockfeed/datatransformation/interpolation/TimeSeriesInterpolator.java
+++ b/timeseries-sources/sources-stockfeed/src/main/java/com/leonarduk/finance/stockfeed/datatransformation/interpolation/TimeSeriesInterpolator.java
@@ -2,7 +2,7 @@ package com.leonarduk.finance.stockfeed.datatransformation.interpolation;
 
 import com.leonarduk.finance.stockfeed.datatransformation.DataTransformer;
 import org.ta4j.core.Bar;
-import org.ta4j.core.TimeSeries;
+import org.ta4j.core.BarSeries;
 
 import java.io.IOException;
 import java.util.List;
@@ -14,7 +14,7 @@ public interface TimeSeriesInterpolator extends DataTransformer {
         return interpolate(history);
     }
 
-    TimeSeries interpolate(TimeSeries series);
+    BarSeries interpolate(BarSeries series);
 
     List<Bar> interpolate(List<Bar> series) throws IOException;
 }

--- a/timeseries-sources/sources-stockfeed/src/main/java/com/leonarduk/finance/stockfeed/feed/ExtendedHistoricalQuoteTimeSeries.java
+++ b/timeseries-sources/sources-stockfeed/src/main/java/com/leonarduk/finance/stockfeed/feed/ExtendedHistoricalQuoteTimeSeries.java
@@ -2,7 +2,7 @@ package com.leonarduk.finance.stockfeed.feed;
 
 import com.google.common.collect.Lists;
 import org.ta4j.core.Bar;
-import org.ta4j.core.TimeSeries;
+import org.ta4j.core.BarSeries;
 import org.ta4j.core.num.DoubleNum;
 import org.ta4j.core.num.Num;
 
@@ -12,7 +12,7 @@ import java.util.List;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
-public class ExtendedHistoricalQuoteTimeSeries implements TimeSeries {
+public class ExtendedHistoricalQuoteTimeSeries implements BarSeries {
 
     /**
      *
@@ -124,7 +124,7 @@ public class ExtendedHistoricalQuoteTimeSeries implements TimeSeries {
     }
 
     @Override
-    public TimeSeries getSubSeries(int startIndex, int endIndex) {
+    public BarSeries getSubSeries(int startIndex, int endIndex) {
         return new ExtendedHistoricalQuoteTimeSeries(series.subList(startIndex, endIndex));
     }
 

--- a/timeseries-sources/sources-stockfeed/src/main/java/com/leonarduk/finance/stockfeed/file/IndicatorsToCsv.java
+++ b/timeseries-sources/sources-stockfeed/src/main/java/com/leonarduk/finance/stockfeed/file/IndicatorsToCsv.java
@@ -25,7 +25,7 @@ package com.leonarduk.finance.stockfeed.file;
 
 import com.leonarduk.finance.utils.FileUtils;
 import com.leonarduk.finance.utils.StringUtils;
-import org.ta4j.core.TimeSeries;
+import org.ta4j.core.BarSeries;
 import org.ta4j.core.indicators.*;
 import org.ta4j.core.indicators.helpers.ClosePriceIndicator;
 import org.ta4j.core.indicators.helpers.PriceVariationIndicator;
@@ -37,7 +37,7 @@ import org.ta4j.core.indicators.statistics.StandardDeviationIndicator;
  */
 public class IndicatorsToCsv {
 
-    public static void exportIndicatorsToCsv(final TimeSeries series) {
+    public static void exportIndicatorsToCsv(final BarSeries series) {
         final String fileName = "target/" + series.getName() + "_indicators.csv";
         /**
          * Creating indicators

--- a/timeseries-sources/sources-stockfeed/src/main/java/com/leonarduk/finance/utils/TimeseriesUtils.java
+++ b/timeseries-sources/sources-stockfeed/src/main/java/com/leonarduk/finance/utils/TimeseriesUtils.java
@@ -11,8 +11,8 @@ import com.leonarduk.finance.stockfeed.feed.ExtendedHistoricalQuote;
 import com.leonarduk.finance.stockfeed.feed.yahoofinance.StockV1;
 import com.leonarduk.finance.stockfeed.file.FileBasedDataStore;
 import org.ta4j.core.Bar;
-import org.ta4j.core.BaseTimeSeries;
-import org.ta4j.core.TimeSeries;
+import org.ta4j.core.BarSeries;
+import org.ta4j.core.BaseBarSeries;
 import org.ta4j.core.num.DoubleNum;
 
 import java.io.IOException;
@@ -69,11 +69,11 @@ public class TimeseriesUtils {
         return history.get(0);
     }
 
-    public static TimeSeries getTimeSeries(final StockV1 stock, final int i, boolean addLatestQuoteToTheSeries) throws IOException {
+    public static BarSeries getTimeSeries(final StockV1 stock, final int i, boolean addLatestQuoteToTheSeries) throws IOException {
         return TimeseriesUtils.getTimeSeries(stock, LocalDate.now().minusYears(i), LocalDate.now(), addLatestQuoteToTheSeries);
     }
 
-    public static TimeSeries getTimeSeries(final StockV1 stock, final LocalDate fromDate, final LocalDate toDate, boolean addLatestQuoteToTheSeries)
+    public static BarSeries getTimeSeries(final StockV1 stock, final LocalDate fromDate, final LocalDate toDate, boolean addLatestQuoteToTheSeries)
             throws IOException {
         List<Bar> history = stock.getHistory();
         if ((null == history) || history.isEmpty()) {
@@ -98,7 +98,7 @@ public class TimeseriesUtils {
                 return null;
             }
         }
-        return new LinearInterpolator().interpolate(new BaseTimeSeries(stock.getName(), ticks));
+        return new LinearInterpolator().interpolate(new BaseBarSeries(stock.getName(), ticks));
     }
 
     public static Bar createSyntheticQuote(final Bar currentQuote, final LocalDate currentDate,
@@ -122,7 +122,7 @@ public class TimeseriesUtils {
                 DoubleNum.valueOf(0), comment);
     }
 
-    public static Iterator<Bar> getTimeSeriesIterator(final TimeSeries series) {
+    public static Iterator<Bar> getTimeSeriesIterator(final BarSeries series) {
         final Iterator<Bar> iter = new Iterator<Bar>() {
             int index = series.getBeginIndex();
 

--- a/timeseries-sources/sources-stockfeed/src/test/java/com/leonarduk/finance/stockfeed/interpolation/FlatLineInterpolatorTest.java
+++ b/timeseries-sources/sources-stockfeed/src/test/java/com/leonarduk/finance/stockfeed/interpolation/FlatLineInterpolatorTest.java
@@ -8,8 +8,8 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.ta4j.core.Bar;
-import org.ta4j.core.BaseTimeSeries;
-import org.ta4j.core.TimeSeries;
+import org.ta4j.core.BarSeries;
+import org.ta4j.core.BaseBarSeries;
 
 import java.time.LocalDate;
 import java.util.Arrays;
@@ -18,7 +18,7 @@ import java.util.stream.Collectors;
 
 public class FlatLineInterpolatorTest {
     private TimeSeriesInterpolator interpolator;
-    private TimeSeries series;
+    private BarSeries series;
 
     @Before
     public void setUp() throws Exception {
@@ -32,13 +32,13 @@ public class FlatLineInterpolatorTest {
                         105.0, 1000.0, 0, ""));
 
         final List<Bar> ticks = quotes.stream().map(q -> new ExtendedHistoricalQuote(q)).collect(Collectors.toList());
-        this.series = new BaseTimeSeries(ticks);
+        this.series = new BaseBarSeries(ticks);
     }
 
     @Test
     public void testInterpolateTimeSeries() {
 
-        final TimeSeries actual = this.interpolator.interpolate(this.series);
+        final BarSeries actual = this.interpolator.interpolate(this.series);
         Assert.assertEquals(10, actual.getBarCount());
         Assert.assertEquals(LocalDate.parse("2017-04-03"), actual.getBar(0).getEndTime().toLocalDate());
         Assert.assertEquals(LocalDate.parse("2017-04-04"), actual.getBar(1).getEndTime().toLocalDate());

--- a/timeseries-sources/sources-stockfeed/src/test/java/com/leonarduk/finance/stockfeed/interpolation/LinearInterpolatorTest.java
+++ b/timeseries-sources/sources-stockfeed/src/test/java/com/leonarduk/finance/stockfeed/interpolation/LinearInterpolatorTest.java
@@ -9,8 +9,8 @@ import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.ta4j.core.Bar;
-import org.ta4j.core.BaseTimeSeries;
-import org.ta4j.core.TimeSeries;
+import org.ta4j.core.BarSeries;
+import org.ta4j.core.BaseBarSeries;
 import org.ta4j.core.num.DoubleNum;
 
 import java.time.LocalDate;
@@ -20,7 +20,7 @@ import java.util.stream.Collectors;
 
 public class LinearInterpolatorTest {
     private TimeSeriesInterpolator interpolator;
-    private TimeSeries series;
+    private BarSeries series;
     private List<ExtendedHistoricalQuote> quotes;
 
     @Before
@@ -35,13 +35,13 @@ public class LinearInterpolatorTest {
                         110.0, 2000.0, 0, ""));
 
         final List<Bar> ticks = quotes.stream().map(q -> new ExtendedHistoricalQuote(q)).collect(Collectors.toList());
-        this.series = new BaseTimeSeries(ticks);
+        this.series = new BaseBarSeries(ticks);
     }
 
     @Test
     @Ignore
     public void testInterpolateTimeseries() {
-        final TimeSeries actual = this.interpolator.interpolate(this.series);
+        final BarSeries actual = this.interpolator.interpolate(this.series);
         Assert.assertEquals(10, actual.getBarCount());
         Assert.assertEquals(LocalDate.parse("2017-04-03"), actual.getBar(0).getEndTime().toLocalDate());
         Assert.assertEquals(LocalDate.parse("2017-04-04"), actual.getBar(1).getEndTime().toLocalDate());


### PR DESCRIPTION
## Summary
- migrate from deprecated `TimeSeries`/`BaseTimeSeries` to `BarSeries`/`BaseBarSeries`
- update utility and interpolator classes to use new TA4J bar series types
- adjust tests to work with `BarSeries`

## Testing
- `mvn -q -e test` *(fails: Non-resolvable import POM: Blocked mirror for repositories: central.maven.org)*
- `mvn -q -e -pl timeseries-sources test` *(fails: Non-resolvable import POM: Blocked mirror for repositories: central.maven.org)*

------
https://chatgpt.com/codex/tasks/task_e_689cacdf6f588327a07f164500eeab79