### PR TITLE
Remove webscraper-core dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,6 @@ Uses:
 * [patriques82/alphavantage4j](https://github.com/patriques82/alphavantage4j) - I had to include this in my code base, as the provided maven repo was unstable.  This also made it easier to make a small bug fix.
 * [sstrickx/yahoofinance-api](https://github.com/sstrickx/yahoofinance-api)  - copied to my code as this seems dead now, and I wanted to make a small change to fit the code into my code
 * [ta4j/ta4j](https://github.com/ta4j/ta4j)
-* [leonarduk/webscraper-core](https://github.com/leonarduk/webscraper-core)
 
 # timeseries-spring-boot-server
 

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,6 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <rest.assured.version>2.3.3</rest.assured.version>
         <org.ta4j.version>0.12</org.ta4j.version>
-        <webscraper-core.version>1.0.23</webscraper-core.version>
         <org.apache.commons.version>3.18.0</org.apache.commons.version>
         <javax.xml.bind.version>2.4.0-b180830.0359</javax.xml.bind.version>
     </properties>

--- a/timeseries-sources/pom.xml
+++ b/timeseries-sources/pom.xml
@@ -17,7 +17,6 @@
 	<name>timeseries-sources</name>
 
         <properties>
-                <aws-java-sdk-bom.version>1.12.738</aws-java-sdk-bom.version>
                 <start-class>com.leonarduk.finance.springboot.App</start-class>
                 <jakarta.persistence.version>2.2.3</jakarta.persistence.version>
                 <org.seleniumhq.selenium.version>4.13.0</org.seleniumhq.selenium.version>
@@ -29,28 +28,12 @@
         </properties>
 
 	<repositories>
-		<repository>
-			<id>sonatype</id>
-			<url>https://oss.sonatype.org/content/groups/public</url>
-		</repository>
-		<repository>
-			<id>central.maven.org</id>
-			<url>http://central.maven.org/maven2/</url>
-		</repository>
-	</repositories>
-        <dependencyManagement>
-                <dependencies>
-                        <dependency>
-                                <groupId>com.amazonaws</groupId>
-                                <artifactId>aws-java-sdk-bom</artifactId>
-				<version>${aws-java-sdk-bom.version}</version>
-				<type>pom</type>
-				<scope>import</scope>
-			</dependency>
-		</dependencies>
-	</dependencyManagement>
-
-	<dependencies>
+                <repository>
+                        <id>central</id>
+                        <url>https://repo1.maven.org/maven2/</url>
+                </repository>
+        </repositories>
+        <dependencies>
 
                 <!-- https://mvnrepository.com/artifact/com.google.guava/guava -->
                 <dependency>
@@ -73,32 +56,9 @@
                         <version>${yahoofinanceapi.version}</version>
                 </dependency>
 
-		<dependency>
-			<groupId>com.leonarduk</groupId>
-			<artifactId>webscraper-core</artifactId>
-			<version>${webscraper-core.version}</version>
-			<exclusions>
-				<exclusion>
-					<groupId>com.google.code.gson</groupId>
-					<artifactId>gson</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>org.hibernate</groupId>
-					<artifactId>hibernate-entitymanager</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>org.slf4j</groupId>
-					<artifactId>slf4j-simple</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>log4j</groupId>
-					<artifactId>log4j</artifactId>
-				</exclusion>
-			</exclusions>
-		</dependency>
-		<!-- https://mvnrepository.com/artifact/org.seleniumhq.selenium/htmlunit-driver -->
-		<dependency>
-			<groupId>org.seleniumhq.selenium</groupId>
+                <!-- https://mvnrepository.com/artifact/org.seleniumhq.selenium/htmlunit-driver -->
+                <dependency>
+                        <groupId>org.seleniumhq.selenium</groupId>
 			<artifactId>htmlunit-driver</artifactId>
 			<version>${org.seleniumhq.selenium.version}</version>
 		</dependency>

--- a/timeseries-spring-boot-server/pom.xml
+++ b/timeseries-spring-boot-server/pom.xml
@@ -31,17 +31,12 @@
 		<jahoo.finance.version>3.15.0</jahoo.finance.version>
 	</properties>
 
-	<repositories>
-
-		<repository>
-			<id>sonatype</id>
-			<url>https://oss.sonatype.org/content/groups/public</url>
-		</repository>
-		<repository>
-			<id>central.maven.org</id>
-			<url>http://central.maven.org/maven2/</url>
-		</repository>
-	</repositories>
+        <repositories>
+                <repository>
+                        <id>central</id>
+                        <url>https://repo1.maven.org/maven2/</url>
+                </repository>
+        </repositories>
 
 	<dependencies>
 		<!-- https://mvnrepository.com/artifact/org.apache.xmlgraphics/batik-transcoder -->

--- a/timeseries-stockfeed/src/main/java/com/leonarduk/finance/scraper/WebScraper.java
+++ b/timeseries-stockfeed/src/main/java/com/leonarduk/finance/scraper/WebScraper.java
@@ -1,0 +1,50 @@
+package com.leonarduk.finance.scraper;
+
+import java.io.IOException;
+import java.util.Optional;
+import org.htmlunit.WebClient;
+import org.htmlunit.html.DomNode;
+import org.htmlunit.html.HtmlPage;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/** Simple utility for retrieving and parsing web pages. */
+public class WebScraper {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(WebScraper.class);
+
+    /**
+     * Fetch the content of the supplied URL and return the HTML as XML.
+     *
+     * @param url page to retrieve
+     * @return HTML content as XML
+     * @throws IOException if the request fails
+     */
+    public String getPageAsXml(final String url) throws IOException {
+        try (WebClient client = new WebClient()) {
+            client.getOptions().setThrowExceptionOnScriptError(false);
+            HtmlPage page = client.getPage(url);
+            return page.asXml();
+        }
+    }
+
+    /**
+     * Retrieve the first node matching the supplied XPath expression and return
+     * its normalised text.
+     *
+     * @param url page to retrieve
+     * @param xpath XPath expression to evaluate
+     * @return optional normalised text for the first matching node
+     * @throws IOException if the request fails
+     */
+    public Optional<String> getTextByXPath(final String url, final String xpath)
+            throws IOException {
+        try (WebClient client = new WebClient()) {
+            client.getOptions().setThrowExceptionOnScriptError(false);
+            HtmlPage page = client.getPage(url);
+            DomNode node = page.getFirstByXPath(xpath);
+            return node == null ? Optional.empty() : Optional.ofNullable(node.asNormalizedText());
+        }
+    }
+}
+

--- a/timeseries-stockfeed/src/main/java/module-info.java
+++ b/timeseries-stockfeed/src/main/java/module-info.java
@@ -6,16 +6,17 @@ module timeseries.stockfeed {
     exports com.leonarduk.finance.stockfeed.datatransformation.correction;
     exports com.leonarduk.finance.stockfeed.feed;
     exports com.leonarduk.finance.stockfeed.feed.yahoofinance;
+    exports com.leonarduk.finance.scraper;
     requires alphavantage4j;
     requires com.google.common;
     requires htmlunit.driver;
     requires http.request;
     requires influxdb.client.core;
     requires org.apache.commons.lang3;
+    requires org.htmlunit;
     requires org.seleniumhq.selenium.api;
     requires org.slf4j;
     requires ta4j.core;
-    requires webscraper.core;
     requires YahooFinanceAPI;
     requires com.fasterxml.jackson.annotation;
 }


### PR DESCRIPTION
## Summary
- Drop webscraper-core property and dependency
- Introduce simple internal WebScraper utility backed by HtmlUnit
- Update module exports and clean up repository definitions

## Testing
- `mvn -q -ntp test` *(fails: Non-resolvable parent POM for timeseries-spring-boot-server due to network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689cacf97bec8327ad3bb61433fc6785