### PR TITLE
chore: bump YahooFinanceAPI dependencies

### DIFF
--- a/timeseries-sources/pom.xml
+++ b/timeseries-sources/pom.xml
@@ -52,19 +52,41 @@
 
 	<dependencies>
 
-                <!-- https://mvnrepository.com/artifact/com.google.guava/guava -->
-                <dependency>
-                        <groupId>com.google.guava</groupId>
-                        <artifactId>guava</artifactId>
-                        <version>32.1.3-jre</version>
-                </dependency>
+               <!-- https://mvnrepository.com/artifact/com.google.guava/guava -->
+               <dependency>
+                       <groupId>com.google.guava</groupId>
+                       <artifactId>guava</artifactId>
+                       <version>33.4.8-jre</version>
+               </dependency>
 
-                <!-- Official AlphaVantage client -->
-                <dependency>
-                        <groupId>com.github.patriques</groupId>
-                        <artifactId>alphavantage4j</artifactId>
-                        <version>${alphavantage4j.version}</version>
-                </dependency>
+               <!-- https://mvnrepository.com/artifact/com.fasterxml.jackson.core/jackson-databind -->
+               <dependency>
+                       <groupId>com.fasterxml.jackson.core</groupId>
+                       <artifactId>jackson-databind</artifactId>
+                       <version>2.19.0</version>
+               </dependency>
+
+               <!-- https://mvnrepository.com/artifact/org.projectlombok/lombok -->
+               <dependency>
+                       <groupId>org.projectlombok</groupId>
+                       <artifactId>lombok</artifactId>
+                       <version>1.18.38</version>
+                       <scope>provided</scope>
+               </dependency>
+
+               <!-- https://mvnrepository.com/artifact/org.yaml/snakeyaml -->
+               <dependency>
+                       <groupId>org.yaml</groupId>
+                       <artifactId>snakeyaml</artifactId>
+                       <version>2.4</version>
+               </dependency>
+
+               <!-- Official AlphaVantage client -->
+               <dependency>
+                       <groupId>com.github.patriques</groupId>
+                       <artifactId>alphavantage4j</artifactId>
+                       <version>${alphavantage4j.version}</version>
+               </dependency>
 
                 <!-- Official Yahoo Finance API -->
                 <dependency>
@@ -142,11 +164,11 @@
 			<artifactId>log4jdbc-log4j2-jdbc4.1</artifactId>
 			<version>${log4jdbc.log4j2.version}</version>
 		</dependency>
-		<dependency>
-			<groupId>org.slf4j</groupId>
-			<artifactId>slf4j-api</artifactId>
-			<version>${org.slf4j.version}</version>
-		</dependency>
+               <dependency>
+                       <groupId>org.slf4j</groupId>
+                       <artifactId>slf4j-api</artifactId>
+                       <version>2.0.17</version>
+               </dependency>
 		<!-- ta4j -->
 		<dependency>
 			<groupId>org.ta4j</groupId>


### PR DESCRIPTION
## Summary
- update YahooFinanceAPI-related dependencies: slf4j-api 2.0.17, jackson-databind 2.19.0, lombok 1.18.38, guava 33.4.8-jre, snakeyaml 2.4

## Testing
- `mvn -q -pl timeseries-sources test` *(fails: Non-resolvable parent POM due to network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689cad129ac08327bcfd6b68676bfe9b