### PR TITLE
Fix POM schema location

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <project xmlns="https://maven.apache.org/POM/4.0.0" xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="https://maven.apache.org/POM/4.0.0 https   ://maven.apache.org/maven-v4_0_0.xsd">
+         xsi:schemaLocation="https://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.leonarduk</groupId>


### PR DESCRIPTION
## Summary
- Correct Maven POM schemaLocation URL to use proper https link

## Testing
- `mvn -N validate`


------
https://chatgpt.com/codex/tasks/task_e_689caccc2154832788c484d9aa81762e