### PR TITLE
chore: use https in custom Maven settings

### DIFF
--- a/.mvn/custom-settings.xml
+++ b/.mvn/custom-settings.xml
@@ -1,12 +1,12 @@
 <settings xmlns="http://maven.apache.org/SETTINGS/1.2.0"
           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.2.0 http://maven.apache.org/xsd/settings-1.2.0.xsd">
+          xsi:schemaLocation="https://maven.apache.org/SETTINGS/1.2.0 https://maven.apache.org/xsd/settings-1.2.0.xsd">
     <mirrors>
         <mirror>
             <id>releases-java-net-http-unblocker</id>
             <mirrorOf>releases.java.net</mirrorOf>
             <name>releases.java.net</name>
-            <url>http://maven.java.net/content/repositories/releases/</url>
+            <url>https://maven.java.net/content/repositories/releases/</url>
             <blocked>false</blocked>
         </mirror>
     </mirrors>


### PR DESCRIPTION
## Summary
- use HTTPS for Maven schema and mirror URL in custom settings

## Testing
- `mvn -N -s .mvn/custom-settings.xml help:effective-settings` *(fails: No plugin found for prefix 'help' and network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689cacd279688327a75c094f1a3d65c7