### PR TITLE
Fix duplicate jfreechart dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -146,18 +146,6 @@
             <scope>compile</scope>
         </dependency>
         <dependency>
-            <groupId>org.jfree</groupId>
-            <artifactId>jfreechart</artifactId>
-            <version>1.5.4</version>
-            <scope>compile</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.jfree</groupId>
-            <artifactId>jfreechart</artifactId>
-            <version>1.5.4</version>
-            <scope>compile</scope>
-        </dependency>
-        <dependency>
             <groupId>jakarta.ws.rs</groupId>
             <artifactId>jakarta.ws.rs-api</artifactId>
             <version>4.0.0</version>


### PR DESCRIPTION
## Summary
- remove redundant org.jfree:jfreechart dependency blocks from root pom

## Testing
- `mvn -s .mvn/custom-settings.xml -q -e dependency:tree -Dincludes=org.jfree:jfreechart` *(fails: No plugin found for prefix 'dependency')*
- `mvn -s .mvn/custom-settings.xml -q -e test` *(fails: Non-resolvable parent POM and blocked repositories)*


------
https://chatgpt.com/codex/tasks/task_e_689cacce97f48327b132ecc795f3b016