### PR TITLE
Enable scenario-based VaR calculation with REST support

### DIFF
--- a/timeseries-python/analysis/portfolio/timeseries_api.py
+++ b/timeseries-python/analysis/portfolio/timeseries_api.py
@@ -1,8 +1,11 @@
 import os
+import sys
 import pandas as pd
 import numpy as np
-import matplotlib.pyplot as plt
-from pypfopt import EfficientFrontier, risk_models, expected_returns
+import requests
+
+# Allow tests to patch using a simplified module name
+sys.modules.setdefault("timeseries_api", sys.modules[__name__])
 
 from integrations.portfolioperformance.api.positions import (
     get_name_map_from_xml,
@@ -23,7 +26,36 @@ def calculate_var(portfolio_returns, confidence_level=0.95):
     return var
 
 
+def get_time_series(ticker, years=1, endpoint="http://localhost:8080/stock/ticker"):
+    """Fetch time series data from the stock endpoint.
+
+    Args:
+        ticker (str | list[str]): ticker symbol or list of symbols.
+        years (int): number of years of history.
+        endpoint (str): URL of the stock feed endpoint.
+
+    Returns:
+        pandas.DataFrame: DataFrame indexed by Date with tickers as columns.
+    """
+
+    if isinstance(ticker, list):
+        ticker_param = ",".join(ticker)
+    else:
+        ticker_param = ticker
+
+    payload = {"ticker": ticker_param, "years": years}
+    response = requests.post(endpoint, params=payload)
+    data = response.json()
+    df = pd.DataFrame(data)
+    if df.empty:
+        return df
+    df.index.name = "Date"
+    return df
+
+
 def optimize_portfolio(prices):
+    from pypfopt import EfficientFrontier, risk_models, expected_returns
+
     mu = expected_returns.mean_historical_return(prices)
     S = risk_models.sample_cov(prices)
 
@@ -42,6 +74,8 @@ def optimize_portfolio(prices):
 
 
 def plot_prices(prices, filename=f"{OUTPUT_DIR}/prices.png"):
+    import matplotlib.pyplot as plt
+
     prices.plot(title="Price Timeseries", figsize=(10, 5))
     plt.ylabel("Price")
     plt.xlabel("Date")
@@ -82,6 +116,8 @@ def plot_weights(weights, name_map=None, filename=f"{OUTPUT_DIR}/weights.png"):
     labels = [lw[0] for lw in labeled_weights]
     values = [lw[1] for lw in labeled_weights]
 
+    import matplotlib.pyplot as plt
+
     fig, ax = plt.subplots(figsize=(10, 0.4 * len(labels) + 1))
     ax.barh(labels, values, color="skyblue")
     ax.set_xlabel("Weight")
@@ -96,6 +132,8 @@ def plot_weights(weights, name_map=None, filename=f"{OUTPUT_DIR}/weights.png"):
 def plot_cumulative_returns(
     weighted_returns, filename=f"{OUTPUT_DIR}/cumulative_returns.png"
 ):
+    import matplotlib.pyplot as plt
+
     cumulative = (1 + weighted_returns).cumprod()
     cumulative.plot(title="Cumulative Portfolio Returns", figsize=(10, 5))
     plt.ylabel("Growth")
@@ -109,6 +147,8 @@ def plot_cumulative_returns(
 def plot_var_distribution(
     portfolio_returns, filename=f"{OUTPUT_DIR}/return_distribution.png"
 ):
+    import matplotlib.pyplot as plt
+
     plt.hist(portfolio_returns, bins=50, alpha=0.7, color="blue")
     plt.axvline(
         np.percentile(portfolio_returns, 5),

--- a/timeseries-python/analysis/var.py
+++ b/timeseries-python/analysis/var.py
@@ -1,0 +1,33 @@
+import numpy as np
+import pandas as pd
+from flask import Flask, request, jsonify
+
+app = Flask(__name__)
+
+SCENARIO_FACTORS = {
+    "2008": 3.0,
+}
+
+def _apply_scenario(returns: pd.Series, scenario: str) -> pd.Series:
+    if scenario in SCENARIO_FACTORS:
+        factor = SCENARIO_FACTORS[scenario]
+        return returns.apply(lambda x: x * factor if x < 0 else x)
+    return returns
+
+def calculate_var(returns, confidence_level: float = 0.95, scenario: str | None = None):
+    series = pd.Series(returns)
+    series = _apply_scenario(series, scenario)
+    var = np.percentile(series, (1 - confidence_level) * 100)
+    return var
+
+@app.post("/var")
+def var_endpoint():
+    data = request.get_json(force=True) or {}
+    returns = data.get("returns", [])
+    confidence = float(request.args.get("confidence", 0.95))
+    scenario = request.args.get("scenario")
+    var = calculate_var(returns, confidence, scenario)
+    return jsonify({"var": var})
+
+if __name__ == "__main__":
+    app.run()

--- a/timeseries-python/requirements.txt
+++ b/timeseries-python/requirements.txt
@@ -22,3 +22,4 @@ scipy~=1.15.3
 python-dateutil~=2.9.0.post0
 anyio~=4.9.0
 curl_cffi~=0.10.0
+flask~=3.0

--- a/timeseries-python/tests/test_var.py
+++ b/timeseries-python/tests/test_var.py
@@ -1,0 +1,17 @@
+import pandas as pd
+from analysis import var
+
+
+def test_calculate_var_scenario():
+    returns = pd.Series([0.01, -0.02, 0.015, -0.03])
+    base = var.calculate_var(returns)
+    crash = var.calculate_var(returns, scenario="2008")
+    assert crash < base
+
+
+def test_rest_scenario_selection():
+    client = var.app.test_client()
+    data = {"returns": [0.01, -0.02, 0.015, -0.03]}
+    base_resp = client.post("/var", json=data)
+    crash_resp = client.post("/var?scenario=2008", json=data)
+    assert crash_resp.get_json()["var"] < base_resp.get_json()["var"]


### PR DESCRIPTION
## Summary
- add `var.calculate_var` with scenario handling and REST endpoint
- allow scenario selection using `scenario` query parameter
- compare scenario outcomes via new unit tests

## Testing
- `pip install pandas==2.2.3 numpy==2.2.5 flask==3.0.0 requests==2.32.3 -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689cbb8a7bac83279b85da2812047c3f