### PR TITLE
Add max drawdown risk analysis endpoint and tests

### DIFF
--- a/timeseries-spring-boot-server/src/main/java/com/leonarduk/finance/springboot/RiskAnalysisEndpoint.java
+++ b/timeseries-spring-boot-server/src/main/java/com/leonarduk/finance/springboot/RiskAnalysisEndpoint.java
@@ -1,0 +1,36 @@
+package com.leonarduk.finance.springboot;
+
+import com.leonarduk.finance.springboot.analysis.RiskAnalysisService;
+import java.util.List;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * REST endpoint exposing risk analysis metrics.
+ */
+@RestController
+@RequestMapping("/risk")
+public class RiskAnalysisEndpoint {
+
+    private final RiskAnalysisService riskAnalysisService;
+
+    @Autowired
+    public RiskAnalysisEndpoint(RiskAnalysisService riskAnalysisService) {
+        this.riskAnalysisService = riskAnalysisService;
+    }
+
+    /**
+     * Calculate the maximum drawdown for a list of prices.
+     *
+     * @param prices ordered list of prices in JSON array format
+     * @return maximum drawdown as decimal (e.g. 0.2 for 20%)
+     */
+    @PostMapping("/maxdrawdown")
+    public double maxDrawdown(@RequestBody List<Double> prices) {
+        return this.riskAnalysisService.calculateMaxDrawdown(prices);
+    }
+}
+

--- a/timeseries-spring-boot-server/src/main/java/com/leonarduk/finance/springboot/analysis/RiskAnalysisService.java
+++ b/timeseries-spring-boot-server/src/main/java/com/leonarduk/finance/springboot/analysis/RiskAnalysisService.java
@@ -1,0 +1,38 @@
+package com.leonarduk.finance.springboot.analysis;
+
+import java.util.List;
+import org.springframework.stereotype.Service;
+
+/**
+ * Service providing basic risk analysis metrics.
+ */
+@Service
+public class RiskAnalysisService {
+
+    /**
+     * Calculate the maximum drawdown of a series of prices.
+     * Max drawdown is defined as the largest peak-to-trough decline
+     * as a fraction of the peak value.
+     *
+     * @param prices ordered list of prices
+     * @return max drawdown as a decimal fraction (e.g. 0.2 for 20%)
+     */
+    public double calculateMaxDrawdown(List<Double> prices) {
+        if (prices == null || prices.isEmpty()) {
+            return 0.0;
+        }
+        double peak = prices.get(0);
+        double maxDrawdown = 0.0;
+        for (double price : prices) {
+            if (price > peak) {
+                peak = price;
+            }
+            double drawdown = (peak - price) / peak;
+            if (drawdown > maxDrawdown) {
+                maxDrawdown = drawdown;
+            }
+        }
+        return maxDrawdown;
+    }
+}
+

--- a/timeseries-spring-boot-server/src/test/java/com/leonarduk/finance/springboot/RiskAnalysisEndpointTest.java
+++ b/timeseries-spring-boot-server/src/test/java/com/leonarduk/finance/springboot/RiskAnalysisEndpointTest.java
@@ -1,0 +1,41 @@
+package com.leonarduk.finance.springboot;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.leonarduk.finance.springboot.analysis.RiskAnalysisService;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(RiskAnalysisEndpoint.class)
+class RiskAnalysisEndpointTest {
+
+    @Autowired private MockMvc mockMvc;
+
+    @MockBean private RiskAnalysisService riskAnalysisService;
+
+    @Test
+    void returnsMaxDrawdown() throws Exception {
+        List<Double> prices = Arrays.asList(100.0, 120.0, 80.0);
+        when(riskAnalysisService.calculateMaxDrawdown(prices)).thenReturn(0.3333);
+        ObjectMapper mapper = new ObjectMapper();
+
+        mockMvc
+                .perform(
+                        post("/risk/maxdrawdown")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(mapper.writeValueAsString(prices)))
+                .andExpect(status().isOk())
+                .andExpect(content().string("0.3333"));
+    }
+}
+

--- a/timeseries-spring-boot-server/src/test/java/com/leonarduk/finance/springboot/analysis/RiskAnalysisServiceTest.java
+++ b/timeseries-spring-boot-server/src/test/java/com/leonarduk/finance/springboot/analysis/RiskAnalysisServiceTest.java
@@ -1,0 +1,27 @@
+package com.leonarduk.finance.springboot.analysis;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.Arrays;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class RiskAnalysisServiceTest {
+
+    private final RiskAnalysisService service = new RiskAnalysisService();
+
+    @Test
+    void calculatesMaxDrawdown() {
+        List<Double> prices = Arrays.asList(100.0, 120.0, 80.0, 130.0, 70.0);
+        double maxDrawdown = service.calculateMaxDrawdown(prices);
+        assertEquals(0.4615, maxDrawdown, 0.0001);
+    }
+
+    @Test
+    void handlesEmptyPrices() {
+        List<Double> prices = List.of();
+        double maxDrawdown = service.calculateMaxDrawdown(prices);
+        assertEquals(0.0, maxDrawdown, 0.0001);
+    }
+}
+


### PR DESCRIPTION
## Summary
- Implement `RiskAnalysisService` for calculating maximum drawdown
- Expose `/risk/maxdrawdown` REST endpoint to return max drawdown for a price series
- Add unit tests for service logic and endpoint behavior

## Testing
- `mvn -q -pl timeseries-spring-boot-server test` *(fails: Non-resolvable parent POM: network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689cbb89a53c83278730f74e82ad3079