### PR TITLE
Add series mapping utility and API hook with tests

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,4 +11,4 @@ repos:
       - id: flake8
         language_version: python3
         files: ^timeseries-python/.*\.py$
-        args: [--max-line-length=88, --extend-ignore=E203,E266,E501,W503,F401,F403]
+        args: [--max-line-length=88, "--extend-ignore=E203,E266,E501,W503,F401,F403"]

--- a/timeseries-python/analysis/series_mapping.py
+++ b/timeseries-python/analysis/series_mapping.py
@@ -1,0 +1,62 @@
+import pandas as pd
+import requests
+
+DATE = "Date"
+
+
+def align_series(
+    source: pd.Series, target: pd.Series, method: str = "ffill"
+) -> pd.Series:
+    """Align one time series to another using index rebasing.
+
+    The source series is scaled so that its value matches the target
+    at the first overlapping date and then reindexed to the target's
+    index.
+
+    Args:
+        source (pd.Series): Series to be aligned.
+        target (pd.Series): Series providing the desired index.
+        method (str, optional): Method used when reindexing. Defaults to "ffill".
+
+    Returns:
+        pd.Series: Source series rebased and indexed like the target.
+    """
+    intersection = source.index.intersection(target.index)
+    if intersection.empty:
+        raise ValueError("No overlapping dates to align series")
+
+    start = intersection.min()
+    scale = target.loc[start] / source.loc[start]
+    rebased = source * scale
+
+    return rebased.reindex(target.index, method=method)
+
+
+def get_mapped_series(
+    source_ticker: str, target_ticker: str, years: int = 0
+) -> pd.Series:
+    """Fetch a mapped series from the timeseries service.
+
+    Args:
+        source_ticker (str): Ticker to map.
+        target_ticker (str): Ticker providing the target index.
+        years (int, optional): Limit of historical data. Defaults to 0 (all).
+
+    Returns:
+        pd.Series: Mapped source series aligned to the target's index.
+    """
+    params = f"source={source_ticker}&target={target_ticker}"
+    if years > 0:
+        params += f"&years={years}"
+    url = f"http://localhost:8091/series/map?{params}"
+
+    response = requests.post(url=url)
+    data = response.json()
+    mapped_key = data.get("mapped") or data.get(source_ticker)
+    if not mapped_key:
+        return pd.Series(dtype=float)
+
+    df = pd.DataFrame(mapped_key.items(), columns=[DATE, source_ticker])
+    df[DATE] = pd.to_datetime(df[DATE])
+    df.set_index(DATE, inplace=True)
+    return df[source_ticker]

--- a/timeseries-python/tests/test_series_mapping.py
+++ b/timeseries-python/tests/test_series_mapping.py
@@ -1,0 +1,56 @@
+import os
+import sys
+import unittest
+from unittest.mock import patch, MagicMock
+import pandas as pd
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from analysis.series_mapping import align_series, get_mapped_series  # noqa: E402
+
+
+class TestSeriesMapping(unittest.TestCase):
+    def test_align_series_rebases_and_reindexes(self):
+        source = pd.Series(
+            [100, 110, 120],
+            index=pd.to_datetime(["2023-01-01", "2023-01-02", "2023-01-04"]),
+        )
+        target = pd.Series(
+            [50, 55, 53, 58],
+            index=pd.to_datetime(
+                ["2023-01-01", "2023-01-02", "2023-01-03", "2023-01-04"]
+            ),
+        )
+
+        aligned = align_series(source, target)
+
+        expected = pd.Series(
+            [50, 55, 55, 60],
+            index=pd.to_datetime(
+                ["2023-01-01", "2023-01-02", "2023-01-03", "2023-01-04"]
+            ),
+            dtype=float,
+        )
+
+        pd.testing.assert_series_equal(aligned, expected)
+
+    @patch("analysis.series_mapping.requests.post")
+    def test_get_mapped_series_parses_response(self, mock_post):
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "mapped": {
+                "2023-01-01": 50,
+                "2023-01-02": 55,
+            }
+        }
+        mock_post.return_value = mock_response
+
+        result = get_mapped_series("AAPL", "MSFT", years=1)
+
+        self.assertEqual(list(result.index.astype(str)), ["2023-01-01", "2023-01-02"])
+        self.assertEqual(result.iloc[0], 50)
+        mock_post.assert_called_once()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add `align_series` for index rebasing and mapping API helper
- expose `get_mapped_series` to fetch mapped data from `/series/map`
- test series alignment and API parsing
- fix flake8 args quoting in pre-commit config

## Testing
- `pre-commit run --files timeseries-python/analysis/series_mapping.py timeseries-python/tests/test_series_mapping.py .pre-commit-config.yaml`
- `pytest timeseries-python/tests/test_series_mapping.py`


------
https://chatgpt.com/codex/tasks/task_e_689cbb899c90832791cc5f15ea4b3408