### PR TITLE
Add active flag to instruments and filter inactive tickers

### DIFF
--- a/timeseries-stockfeed/src/main/java/com/leonarduk/finance/stockfeed/FxInstrument.java
+++ b/timeseries-stockfeed/src/main/java/com/leonarduk/finance/stockfeed/FxInstrument.java
@@ -7,7 +7,7 @@ public final class FxInstrument extends Instrument {
     public FxInstrument(Source source, String currencyOne, String currencyTwo) {
         super(currencyTwo + "/" + currencyTwo, AssetType.FX, AssetType.FX, Source.ALPHAVANTAGE,
                 currencyOne + currencyTwo, currencyOne + currencyTwo, Exchange.NA, currencyOne, currencyTwo,
-                currencyTwo);
+                currencyTwo, true);
         this.currencyOne = currencyOne;
         this.currencyTwo = currencyTwo;
     }

--- a/timeseries-stockfeed/src/test/java/com/leonarduk/finance/stockfeed/InstrumentLoaderTest.java
+++ b/timeseries-stockfeed/src/test/java/com/leonarduk/finance/stockfeed/InstrumentLoaderTest.java
@@ -1,0 +1,23 @@
+package com.leonarduk.finance.stockfeed;
+
+import org.junit.Test;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.util.Map;
+
+import static org.junit.Assert.*;
+
+public class InstrumentLoaderTest {
+
+    @Test
+    public void testInactiveTickersFilteredOut() throws IOException, URISyntaxException {
+        Instrument.InstrumentLoader loader = new Instrument.InstrumentLoader();
+        loader.init("resources/data/instruments_active_test.csv");
+        Map<String, Instrument> instruments = loader.getInstruments();
+
+        assertTrue("Active instrument should be present", instruments.containsKey("AAA"));
+        assertFalse("Inactive instrument should be filtered out", instruments.containsKey("BBB"));
+    }
+}
+

--- a/timeseries-stockfeed/src/test/resources/resources/data/instruments_active_test.csv
+++ b/timeseries-stockfeed/src/test/resources/resources/data/instruments_active_test.csv
@@ -1,0 +1,4 @@
+Name,AssetType,Underlying,Source,isin,code,Exchange,category,currency,googleCode,active
+Active Instrument,ETF,EQUITY,Google,ISINAAA,AAA,London,Test,GBP,LON:AAA,true
+Inactive Instrument,ETF,EQUITY,Google,ISINBBB,BBB,London,Test,GBP,LON:BBB,false
+


### PR DESCRIPTION
## Summary
- Parse and store an `active` flag in `Instrument` loaded from CSV
- Filter inactive instruments in `InstrumentLoader` and expose `isActive` helpers
- Add regression test ensuring inactive tickers are excluded

## Testing
- `mvn -q -pl timeseries-stockfeed test` *(fails: Non-resolvable parent POM due to network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689cbb6612608327b78a8e835b07d6d6