### PR TITLE
Build and push timeseries-lambda Docker image in Maven workflow

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -2,7 +2,9 @@
 name: Maven Build
 
 on:
-  [push, pull_request]
+  push:
+    branches: [main]
+  pull_request:
 
 jobs:
   build:
@@ -25,6 +27,19 @@ jobs:
           cache: maven
       - name: Build with Maven
         run: mvn -B verify --file pom.xml
+      - name: Log in to container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ secrets.REGISTRY_URL }} # stored in GitHub secrets
+          username: ${{ secrets.REGISTRY_USERNAME }}
+          password: ${{ secrets.REGISTRY_PASSWORD }}
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: ./timeseries-lambda
+          file: ./timeseries-lambda/Dockerfile
+          push: true
+          tags: ${{ secrets.REGISTRY_URL }}/pension-risk-management-system/timeseries-lambda:latest
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v3
       - name: Update dependency graph


### PR DESCRIPTION
## Summary
- build and push the `timeseries-lambda` Docker image during CI
- use encrypted GitHub secrets for registry login
- trigger workflow only on pushes to `main`

## Testing
- `pre-commit run --files .github/workflows/maven.yml`
- `act push -j build -W .github/workflows/maven.yml -P ubuntu-latest=catthehacker/ubuntu:act-latest` *(fails: Cannot connect to the Docker daemon at unix:///var/run/docker.sock)*

------
https://chatgpt.com/codex/tasks/task_e_689cbb78a5b08327b312b0bb97f0c144