### PR TITLE
Filter inactive instruments based on CSV active flag

### DIFF
--- a/timeseries-stockfeed/src/main/java/com/leonarduk/finance/stockfeed/Instrument.java
+++ b/timeseries-stockfeed/src/main/java/com/leonarduk/finance/stockfeed/Instrument.java
@@ -40,8 +40,10 @@ public sealed class Instrument permits FxInstrument {
 
     private AssetType underlyingType;
 
+    private boolean active = true;
+
     public static final Instrument CASH = new Instrument("CASH", AssetType.CASH, AssetType.CASH, Source.MANUAL,
-            Instrument.CASH_TEXT, Instrument.CASH_TEXT, Exchange.LONDON, Instrument.CASH_TEXT, "", Instrument.GBP, "N/A");
+            Instrument.CASH_TEXT, Instrument.CASH_TEXT, Exchange.LONDON, Instrument.CASH_TEXT, "", Instrument.GBP, "N/A", true);
 
     private static final String CASH_TEXT = "Cash";
 
@@ -51,7 +53,7 @@ public sealed class Instrument permits FxInstrument {
 
     public static final Instrument UNKNOWN = new Instrument(Instrument.UNKNOWN_TEXT, AssetType.UNKNOWN,
             AssetType.UNKNOWN, Source.MANUAL, Instrument.UNKNOWN_TEXT, Instrument.UNKNOWN_TEXT, Exchange.LONDON,
-            Instrument.UNKNOWN_TEXT, "", Instrument.GBP, Instrument.UNKNOWN_TEXT);
+            Instrument.UNKNOWN_TEXT, "", Instrument.GBP, Instrument.UNKNOWN_TEXT, true);
 
     private static final String UNKNOWN_TEXT = "UNKNOWN";
 
@@ -107,7 +109,8 @@ public sealed class Instrument permits FxInstrument {
                         StringUtils.defaultIfEmpty(iter.hasNext() ? iter.next() : "", ""),
                         StringUtils.defaultIfEmpty(iter.hasNext() ? iter.next() : "", ""),
                         StringUtils.defaultIfEmpty(iter.hasNext() ? iter.next() : "", ""),
-                        StringUtils.defaultIfEmpty(iter.hasNext() ? iter.next() : "", "")
+                        StringUtils.defaultIfEmpty(iter.hasNext() ? iter.next() : "", ""),
+                        Boolean.parseBoolean(StringUtils.defaultIfEmpty(iter.hasNext() ? iter.next() : "TRUE", "TRUE"))
                 );
             } catch (Exception e) {
                 logger.warn(String.format("Could not map %s to an instrument", line), e);
@@ -118,13 +121,17 @@ public sealed class Instrument permits FxInstrument {
         public void init(String filePath) throws IOException, URISyntaxException {
             this.instruments = ResourceTools.getResourceAsLines(filePath).stream().skip(1)
                     .map(this::create).collect(Collectors.toConcurrentMap(i -> i.getCode(), i -> i));
-            this.getInstruments().values().forEach(i -> this.getInstruments().put(i.getIsin().toUpperCase(), i));
-            this.getInstruments().values().forEach(i -> this.getInstruments().put(i.getGoogleCode().toUpperCase(), i));
-            this.getInstruments().put(Instrument.CASH.isin.toUpperCase(), Instrument.CASH);
+            this.instruments.values().stream().filter(Instrument::isActive)
+                    .forEach(i -> this.instruments.put(i.getIsin().toUpperCase(), i));
+            this.instruments.values().stream().filter(Instrument::isActive)
+                    .forEach(i -> this.instruments.put(i.getGoogleCode().toUpperCase(), i));
+            this.instruments.put(Instrument.CASH.isin.toUpperCase(), Instrument.CASH);
         }
 
         public Map<String, Instrument> getInstruments() {
-            return instruments;
+            return instruments.entrySet().stream()
+                    .filter(e -> e.getValue().isActive())
+                    .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
         }
     }
 
@@ -152,13 +159,13 @@ public sealed class Instrument permits FxInstrument {
         }
 
         return new Instrument(symbol, AssetType.fromString(type), AssetType.fromString(type), Source.MANUAL, symbol, localSymbol,
-                Exchange.valueOf(region), "", "", currency, symbol);
+                Exchange.valueOf(region), "", "", currency, symbol, true);
     }
 
 
     protected Instrument(final String name, final AssetType type, final AssetType underlying, final Source source,
                          final String isin, final String code, final Exchange exchange, final String category, final String indexCategory, final String currency,
-                         final String googleCode) {
+                         final String googleCode, final boolean active) {
         this.assetType = type;
         this.underlyingType = underlying;
         this.source = source;
@@ -170,6 +177,7 @@ public sealed class Instrument permits FxInstrument {
         this.currency = currency;
         this.googleCode = googleCode;
         this.exchange = exchange;
+        this.active = active;
     }
 
     public AssetType assetType() {
@@ -206,7 +214,9 @@ public sealed class Instrument permits FxInstrument {
                 .append(this.code, castOther.code).append(this.currency, castOther.currency)
                 .append(this.exchange, castOther.exchange).append(this.googleCode, castOther.googleCode)
                 .append(this.isin, castOther.isin).append(this.name, castOther.name)
-                .append(this.source, castOther.source).append(this.underlyingType, castOther.underlyingType).isEquals();
+                .append(this.source, castOther.source).append(this.underlyingType, castOther.underlyingType)
+                .append(this.active, castOther.active)
+                .isEquals();
     }
 
     public AssetType getAssetType() {
@@ -249,11 +259,15 @@ public sealed class Instrument permits FxInstrument {
         return this.source;
     }
 
+    public boolean isActive() {
+        return this.active;
+    }
+
     @Override
     public int hashCode() {
         return new HashCodeBuilder().append(this.assetType).append(this.category).append(this.code)
                 .append(this.indexCategory).append(this.currency).append(this.exchange).append(this.googleCode).append(this.isin).append(this.name)
-                .append(this.source).append(this.underlyingType).toHashCode();
+                .append(this.source).append(this.underlyingType).append(this.active).toHashCode();
     }
 
     public String isin() {
@@ -269,7 +283,7 @@ public sealed class Instrument permits FxInstrument {
         return new ToStringBuilder(this).append("assetType", this.assetType).append("category", this.category)
                 .append("indexCategory", this.indexCategory).append("code", this.code).append("currency", this.currency).append("exchange", this.exchange)
                 .append("googleCode", this.googleCode).append("isin", this.isin).append("name", this.name)
-                .append("source", this.source).append("underlyingType", this.underlyingType).toString();
+                .append("source", this.source).append("underlyingType", this.underlyingType).append("active", this.active).toString();
     }
 
     public AssetType underlyingType() {

--- a/timeseries-stockfeed/src/main/resources/resources/data/instruments_list.csv
+++ b/timeseries-stockfeed/src/main/resources/resources/data/instruments_list.csv
@@ -1,11 +1,11 @@
-Name,AssetType,Underlying,Source,isin,code,Exchange,category,indexCategory,currency,googleCode,
+Name,AssetType,Underlying,Source,isin,code,Exchange,category,indexCategory,currency,googleCode,active
 USD per GBP,FX,FX,Yahoo,USDGBP,USDGBP,London,Currency,,GBP,CURRENCY:USDGBP,
 GBP per USD,FX,FX,Yahoo,GBPUSD,GBPUSD,London,Currency,,USD,CURRENCY:GBPUSD,
 ,FUND,EQUITY,Yahoo,GB00B41YBW71,FUQUIT,London,Global Equity,,GBP,MUTF_GB:FUND_EQUI_I_ANRT8N,
 ,FUND,BOND,Yahoo,GB00BD050949,RLAAAI,London,Short duration bond,,GBX,LON:RLAAAI,
 ,FUND,BOND,Yahoo,GB00B1XFKV93,YFEMID,London,MEmerging Bond,,GBX,LON:YFEMID,
 ,FUND,BOND,Yahoo,GB00B45Q9038,VVUILG,London,UK Inflation,,GBP,MUTF_GB:VANG_UK_INFL_1YLF91E,
-Amundi ETF MSCI China EUR A/I GBP,ETF,EQUITY,Google,FR0010713784,CC1,London,China Equity,,GBX,LON:CC1,
+Amundi ETF MSCI China EUR A/I GBP,ETF,EQUITY,Google,FR0010713784,CC1,London,China Equity,,GBX,LON:CC1,FALSE
 Amundi ETF MSCI EM Latin America EUR A/I GBP,ETF,EQUITY,Google,FR0011020973,ALAT,London,Latin America Equity,,GBX,LON:ALAT,
 Amundi ETF MSCI Emerging Markets EUR A/I GBP,ETF,EQUITY,Google,FR0010959676,AEEM,London,Global Emerging Markets Equity,,GBX,LON:AEEM,
 Amundi ETF MSCI Germany A/I GBP,ETF,EQUITY,Google,FR0010655712,CG1,London,Germany Large-Cap Equity,,GBX,LON:CG1,

--- a/timeseries-stockfeed/src/test/java/com/leonarduk/finance/stockfeed/InstrumentTest.java
+++ b/timeseries-stockfeed/src/test/java/com/leonarduk/finance/stockfeed/InstrumentTest.java
@@ -45,4 +45,12 @@ public class InstrumentTest {
 
     }
 
+    @Test
+    public void testInactiveTickerFilteredOut() throws IOException {
+        Instrument.InstrumentLoader loader = Instrument.InstrumentLoader.getInstance();
+        Assert.assertFalse(loader.getInstruments().containsKey("CC1"));
+        Assert.assertTrue(loader.getInstruments().containsKey("XDND"));
+        Assert.assertEquals(Source.MANUAL, Instrument.fromString("CC1").getSource());
+    }
+
 }


### PR DESCRIPTION
## Summary
- extend Instrument with active flag loaded from CSV
- filter InstrumentLoader results to only active instruments
- add regression test ensuring inactive tickers are excluded

## Testing
- `mvn -q -pl timeseries-stockfeed test` *(fails: Non-resolvable parent POM, network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689cc1e1d59c832784eb228025e09cd6