### PR TITLE
Enable configurable CORS in spring boot server

### DIFF
--- a/timeseries-spring-boot-server/src/main/java/com/leonarduk/finance/springboot/config/CorsConfig.java
+++ b/timeseries-spring-boot-server/src/main/java/com/leonarduk/finance/springboot/config/CorsConfig.java
@@ -1,0 +1,22 @@
+package com.leonarduk.finance.springboot.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class CorsConfig implements WebMvcConfigurer {
+
+    @Value("${cors.allowed-origins:*}")
+    private String allowedOrigins;
+
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        String[] origins = allowedOrigins.split(",");
+        registry.addMapping("/**")
+                .allowedOrigins(origins)
+                .allowedMethods("*")
+                .allowedHeaders("*");
+    }
+}

--- a/timeseries-spring-boot-server/src/main/resources/application.properties
+++ b/timeseries-spring-boot-server/src/main/resources/application.properties
@@ -1,2 +1,5 @@
 server.port = 8091
 logging.level.org.springframework=INFO
+
+# Allowed CORS origins
+cors.allowed-origins=*

--- a/timeseries-spring-boot-server/src/test/java/com/leonarduk/finance/springboot/CorsConfigTest.java
+++ b/timeseries-spring-boot-server/src/test/java/com/leonarduk/finance/springboot/CorsConfigTest.java
@@ -1,0 +1,41 @@
+package com.leonarduk.finance.springboot;
+
+import com.leonarduk.finance.springboot.config.CorsConfig;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(CorsConfigTest.TestController.class)
+@Import(CorsConfig.class)
+@TestPropertySource(properties = "cors.allowed-origins=http://example.com")
+class CorsConfigTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @RestController
+    @RequestMapping("/stock")
+    static class TestController {
+        @GetMapping
+        public String get() {
+            return "ok";
+        }
+    }
+
+    @Test
+    void corsHeadersPresent() throws Exception {
+        mockMvc.perform(get("/stock").header("Origin", "http://example.com"))
+                .andExpect(status().isOk())
+                .andExpect(header().string("Access-Control-Allow-Origin", "http://example.com"));
+    }
+}


### PR DESCRIPTION
## Summary
- add `CorsConfig` to configure CORS mappings based on `cors.allowed-origins` property
- expose `cors.allowed-origins` property in application config
- test that `/stock` endpoint returns CORS headers for allowed origins

## Testing
- `mvn -q -pl timeseries-spring-boot-server -am test` *(fails: Non-resolvable parent POM: network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689cbb7f3a8483279d8454121f1742b6