### PR TITLE
feat: add category filter for stock feed

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,3 +39,13 @@ If you select interpolate=true, it will flat-line dates before and after the ava
 e.g.
 http://localhost:8091/stock/ticker/MNP?years=2&interpolate=true&clean=true
 
+You can also restrict the response to instruments belonging to a specific
+category by supplying the `category` query parameter:
+
+```
+http://localhost:8091/stock/ticker/MNP?years=2&category=EQUITY
+```
+
+When requesting JSON data with multiple tickers the same parameter can be used
+to filter out instruments that do not match the selected category.
+


### PR DESCRIPTION
## Summary
- allow StockFeedEndpoint to filter by instrument category
- document the category query parameter in README

## Testing
- `pre-commit run --files README.md timeseries-spring-boot-server/src/main/java/com/leonarduk/finance/springboot/StockFeedEndpoint.java`
- `mvn -q -pl timeseries-spring-boot-server spotless:apply` *(failed: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.5.3)*


------
https://chatgpt.com/codex/tasks/task_e_689cbb82386c8327bb9b4a6b76db1916