### PR TITLE
chore: remove unused webscraper-core property

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,6 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <rest.assured.version>2.3.3</rest.assured.version>
         <org.ta4j.version>0.18</org.ta4j.version>
-        <webscraper-core.version>1.0.23</webscraper-core.version>
         <org.apache.commons.version>3.18.0</org.apache.commons.version>
         <javax.xml.bind.version>2.4.0-b180830.0359</javax.xml.bind.version>
     </properties>


### PR DESCRIPTION
## Summary
- remove unused webscraper-core version property from parent POM

## Testing
- `pre-commit run --files pom.xml`
- `mvn -q -Djava.net.preferIPv4Stack=true clean verify` *(fails: Non-resolvable parent POM due to network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689cbb70b9688327b4d2f78f760461c5