### PR TITLE
chore: update RestAssured version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
         <maven.shade.plugin.version>3.2.1</maven.shade.plugin.version>
         <org.slf4j.version>2.0.17</org.slf4j.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <rest.assured.version>2.3.3</rest.assured.version>
+        <rest.assured.version>5.5.0</rest.assured.version>
         <org.ta4j.version>0.18</org.ta4j.version>
         <org.apache.commons.version>3.18.0</org.apache.commons.version>
         <javax.xml.bind.version>2.4.0-b180830.0359</javax.xml.bind.version>

--- a/timeseries-spring-boot-server/pom.xml
+++ b/timeseries-spring-boot-server/pom.xml
@@ -22,7 +22,7 @@
 		<start-class>com.leonarduk.finance.springboot.App</start-class>
 		<java.version>21</java.version>
 		<log4jdbc.log4j2.version>1.16</log4jdbc.log4j2.version>
-		<rest.assured.version>2.3.3</rest.assured.version>
+                <rest.assured.version>5.5.0</rest.assured.version>
 		<maven.compiler.source>21</maven.compiler.source>
 		<maven.compiler.target>21</maven.compiler.target>
 		<jacoco.version>0.8.13</jacoco.version>


### PR DESCRIPTION
## Summary
- bump RestAssured to 5.5.0 in parent and server modules

## Testing
- `mvn test` *(fails: Non-resolvable import POM: could not transfer artifacts from Maven Central)*

------
https://chatgpt.com/codex/tasks/task_e_689ccf0ff7ac83279630e03dde67a9ff