### PR TITLE
Handle UK bank holidays in interpolation

### DIFF
--- a/timeseries-stockfeed/src/main/java/com/leonarduk/finance/utils/DateUtils.java
+++ b/timeseries-stockfeed/src/main/java/com/leonarduk/finance/utils/DateUtils.java
@@ -67,7 +67,16 @@ public class DateUtils {
             LocalDate.of(2023, 5, 29), // Spring bank holiday
             LocalDate.of(2023, 8, 28), // Summer bank holiday
             LocalDate.of(2023, 12, 25), // Christmas Day
-            LocalDate.of(2023, 12, 26)  // Boxing Day
+            LocalDate.of(2023, 12, 26), // Boxing Day
+            // 2024
+            LocalDate.of(2024, 1, 1), // New Year's Day
+            LocalDate.of(2024, 3, 29), // Good Friday
+            LocalDate.of(2024, 4, 1), // Easter Monday
+            LocalDate.of(2024, 5, 6), // Early May bank holiday
+            LocalDate.of(2024, 5, 27), // Spring bank holiday
+            LocalDate.of(2024, 8, 26), // Summer bank holiday
+            LocalDate.of(2024, 12, 25), // Christmas Day
+            LocalDate.of(2024, 12, 26)  // Boxing Day
     ));
 
     public static LocalDate calendarToLocalDate(Calendar calendar) {

--- a/timeseries-stockfeed/src/test/java/com/leonarduk/finance/stockfeed/interpolation/HolidayInterpolationTest.java
+++ b/timeseries-stockfeed/src/test/java/com/leonarduk/finance/stockfeed/interpolation/HolidayInterpolationTest.java
@@ -20,12 +20,10 @@ import java.util.stream.Collectors;
  * Tests that interpolation skips recognised UK bank holidays.
  */
 public class HolidayInterpolationTest {
-    private TimeSeriesInterpolator interpolator;
     private TimeSeries series;
 
     @Before
     public void setUp() {
-        this.interpolator = new FlatLineInterpolator();
         List<ExtendedHistoricalQuote> quotes = Arrays.asList(
                 new ExtendedHistoricalQuote(Instrument.UNKNOWN, LocalDate.parse("2022-12-23"), 100.0, 100.0, 100.0,
                         100.0, 1000.0, 0, ""),
@@ -36,8 +34,22 @@ public class HolidayInterpolationTest {
     }
 
     @Test
-    public void testSkipsUKBankHolidays() {
-        TimeSeries actual = this.interpolator.interpolate(this.series);
+    public void testSkipsUKBankHolidaysFlatLine() {
+        TimeSeriesInterpolator flat = new FlatLineInterpolator();
+        TimeSeries actual = flat.interpolate(this.series);
+        Assert.assertEquals(2, actual.getBarCount());
+        Assert.assertEquals(LocalDate.parse("2022-12-23"), actual.getBar(0).getEndTime().toLocalDate());
+        Assert.assertEquals(LocalDate.parse("2022-12-28"), actual.getBar(1).getEndTime().toLocalDate());
+        for (int i = 0; i < actual.getBarCount(); i++) {
+            LocalDate date = actual.getBar(i).getEndTime().toLocalDate();
+            Assert.assertFalse(date.equals(LocalDate.parse("2022-12-26")) || date.equals(LocalDate.parse("2022-12-27")));
+        }
+    }
+
+    @Test
+    public void testSkipsUKBankHolidaysLinear() {
+        TimeSeriesInterpolator linear = new com.leonarduk.finance.stockfeed.datatransformation.interpolation.LinearInterpolator();
+        TimeSeries actual = linear.interpolate(this.series);
         Assert.assertEquals(2, actual.getBarCount());
         Assert.assertEquals(LocalDate.parse("2022-12-23"), actual.getBar(0).getEndTime().toLocalDate());
         Assert.assertEquals(LocalDate.parse("2022-12-28"), actual.getBar(1).getEndTime().toLocalDate());

--- a/timeseries-stockfeed/src/test/java/com/leonarduk/finance/utils/DateUtilsTest.java
+++ b/timeseries-stockfeed/src/test/java/com/leonarduk/finance/utils/DateUtilsTest.java
@@ -35,6 +35,22 @@ public class DateUtilsTest {
     }
 
     @Test
+    public void testGetDiffInWorkDaysSkipsBankHolidays() {
+        LocalDate start = LocalDate.parse("2023-04-28");
+        LocalDate end = LocalDate.parse("2023-05-09");
+        Assert.assertEquals(5, DateUtils.getDiffInWorkDays(start, end));
+    }
+
+    @Test
+    public void testLocalDateIteratorSkipsBankHolidays() {
+        Iterator<LocalDate> iter = DateUtils.getLocalDateIterator(LocalDate.parse("2022-12-23"),
+                LocalDate.parse("2022-12-28"));
+        Assert.assertEquals(LocalDate.parse("2022-12-23"), iter.next());
+        Assert.assertEquals(LocalDate.parse("2022-12-28"), iter.next());
+        Assert.assertFalse(iter.hasNext());
+    }
+
+    @Test
     public final void testGetLocalDateIterator() {
         final Iterator<LocalDate> iter = DateUtils.getLocalDateIterator(LocalDate.parse(DateUtilsTest.APRIL3),
                 LocalDate.parse(DateUtilsTest.APRIL10));


### PR DESCRIPTION
## Summary
- extend `DateUtils` with a static list of UK bank holidays through 2024
- ensure interpolation respects holidays for both flat-line and linear algorithms
- add unit tests covering holiday gaps and holiday-aware date utilities

## Testing
- `mvn -q -pl timeseries-stockfeed -am test` *(fails: Could not transfer artifact ... Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689ccf37f8348327a2ecc4956a06d735