### PR TITLE
Add content type assertion for stock endpoint test

### DIFF
--- a/timeseries-spring-boot-server/src/test/java/com/leonarduk/finance/springboot/StockFeedEndpointTest.java
+++ b/timeseries-spring-boot-server/src/test/java/com/leonarduk/finance/springboot/StockFeedEndpointTest.java
@@ -10,6 +10,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.http.MediaType;
 
 import java.time.LocalDate;
 import java.util.Collections;
@@ -43,6 +44,7 @@ class StockFeedEndpointTest {
                         .param("interpolate", "true")
                         .param("cleanDate", "true"))
                 .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.TEXT_HTML))
                 .andExpect(content().string(containsString("<html")));
     }
 }


### PR DESCRIPTION
## Summary
- ensure StockFeedEndpointTest verifies HTML content type for `/stock/ticker/{ticker}`

## Testing
- `mvn -q -pl timeseries-spring-boot-server -am -Daws-java-sdk-bom.version=1.12.704 test` *(fails: Non-resolvable import POM: com.amazonaws:aws-java-sdk-bom)*

------
https://chatgpt.com/codex/tasks/task_e_689ccf332968832789ee5616d3cdd969