### PR TITLE
Add basic UI module with build workflow

### DIFF
--- a/.github/workflows/ui.yml
+++ b/.github/workflows/ui.yml
@@ -1,0 +1,22 @@
+name: UI Build
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ui
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '18'
+          cache: npm
+          cache-dependency-path: ui/package-lock.json
+      - run: npm ci
+      - run: npm run build

--- a/ui/src/App.jsx
+++ b/ui/src/App.jsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import PriceChart from './PriceChart.jsx';
+import TickerTable from './TickerTable.jsx';
 
 export default function App() {
   const [tickers, setTickers] = useState('AAPL');
@@ -20,21 +21,9 @@ export default function App() {
       setError(null);
     } catch (e) {
       setError('Failed to fetch data');
+      setData({});
     }
   };
-
-  const renderRows = () =>
-    Object.entries(data).map(([ticker, prices]) => {
-      const dates = Object.keys(prices);
-      const latestDate = dates[dates.length - 1];
-      const latestPrice = prices[latestDate];
-      return (
-        <tr key={ticker}>
-          <td>{ticker}</td>
-          <td>{latestPrice}</td>
-        </tr>
-      );
-    });
 
   const firstTicker = Object.keys(data)[0];
   const firstPrices = firstTicker ? data[firstTicker] : null;
@@ -52,15 +41,7 @@ export default function App() {
       />
       <button onClick={fetchData}>Load</button>
       {error && <p>{error}</p>}
-      <table>
-        <thead>
-          <tr>
-            <th>Ticker</th>
-            <th>Latest Close</th>
-          </tr>
-        </thead>
-        <tbody>{renderRows()}</tbody>
-      </table>
+      {Object.keys(data).length > 0 && <TickerTable data={data} />}
       {chartLabels.length > 0 && (
         <div style={{ maxWidth: '600px' }}>
           <PriceChart labels={chartLabels} data={chartData} />

--- a/ui/src/TickerTable.jsx
+++ b/ui/src/TickerTable.jsx
@@ -1,0 +1,28 @@
+import React from 'react';
+
+export default function TickerTable({ data }) {
+  const renderRows = () =>
+    Object.entries(data).map(([ticker, prices]) => {
+      const dates = Object.keys(prices);
+      const latestDate = dates[dates.length - 1];
+      const latestPrice = prices[latestDate];
+      return (
+        <tr key={ticker}>
+          <td>{ticker}</td>
+          <td>{latestPrice}</td>
+        </tr>
+      );
+    });
+
+  return (
+    <table>
+      <thead>
+        <tr>
+          <th>Ticker</th>
+          <th>Latest Close</th>
+        </tr>
+      </thead>
+      <tbody>{renderRows()}</tbody>
+    </table>
+  );
+}


### PR DESCRIPTION
## Summary
- display tickers and latest prices in a table
- render simple price chart for first ticker
- build UI as part of CI via dedicated workflow

## Testing
- `npm ci`
- `npm run build`
- `pre-commit run --files ui/src/App.jsx ui/src/TickerTable.jsx .github/workflows/ui.yml`


------
https://chatgpt.com/codex/tasks/task_e_689ccf2d05d08327968f85cf624059f3