### PR TITLE
Use Jackson BOM for consistent 2.17.2 version

### DIFF
--- a/timeseries-sources/pom.xml
+++ b/timeseries-sources/pom.xml
@@ -26,6 +26,7 @@
                 <org.apache.xmlgraphics.version>1.19</org.apache.xmlgraphics.version>
                 <alphavantage4j.version>1.5.0</alphavantage4j.version>
                 <yahoofinanceapi.version>3.17.0</yahoofinanceapi.version>
+                <aws-java-sdk-bom.version>1.12.788</aws-java-sdk-bom.version>
         </properties>
 
         <repositories>
@@ -39,12 +40,19 @@
                         <dependency>
                                 <groupId>com.amazonaws</groupId>
                                 <artifactId>aws-java-sdk-bom</artifactId>
-				<version>${aws-java-sdk-bom.version}</version>
-				<type>pom</type>
-				<scope>import</scope>
-			</dependency>
-		</dependencies>
-	</dependencyManagement>
+                                <version>${aws-java-sdk-bom.version}</version>
+                                <type>pom</type>
+                                <scope>import</scope>
+                        </dependency>
+                        <dependency>
+                                <groupId>com.fasterxml.jackson</groupId>
+                                <artifactId>jackson-bom</artifactId>
+                                <version>2.17.2</version>
+                                <type>pom</type>
+                                <scope>import</scope>
+                        </dependency>
+                </dependencies>
+        </dependencyManagement>
 
 	<dependencies>
 
@@ -59,7 +67,6 @@
                <dependency>
                        <groupId>com.fasterxml.jackson.core</groupId>
                        <artifactId>jackson-databind</artifactId>
-                       <version>2.19.0</version>
                </dependency>
 
                <!-- https://mvnrepository.com/artifact/org.projectlombok/lombok -->


### PR DESCRIPTION
## Summary
- import Jackson BOM (2.17.2) and drop explicit jackson-databind version
- add missing aws-java-sdk BOM version property

## Testing
- `mvn test` *(fails: Non-resolvable parent POM for timeseries-spring-boot-server due to network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689ccf117bd483279e8806423bc7d176