### PR TITLE
feat: add category filtering to stock feed endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ http://localhost:8091/stock/ticker/MNP?years=2&category=EQUITY
 
 When requesting JSON data with multiple tickers the same parameter can be used
 to filter out instruments that do not match the selected category.
-=======
+
 ## timeseries-lambda
 
 The `timeseries-lambda` module runs as a Docker container and requires several

--- a/timeseries-spring-boot-server/src/main/java/com/leonarduk/finance/springboot/StockFeedEndpoint.java
+++ b/timeseries-spring-boot-server/src/main/java/com/leonarduk/finance/springboot/StockFeedEndpoint.java
@@ -54,6 +54,7 @@ public class StockFeedEndpoint {
      * @param scaling optional scaling factor for values
      * @param interpolate whether to interpolate missing data
      * @param cleanDate whether to clean non-trading days
+     * @param category optional instrument category filter
      * @return HTML table with historical stock data
      * @throws IOException if data retrieval fails
      */
@@ -71,10 +72,7 @@ public class StockFeedEndpoint {
                                  @RequestParam(name = "lang", required = false) String lang
     ) throws IOException {
 
-        List<List<DataField>> records = getRecords(ticker, years, fromDate, toDate, fields, scaling, interpolate, cleanDate,
-                category);
-
-      Locale locale = Locale.getDefault();
+        Locale locale = Locale.getDefault();
         if (StringUtils.isNotBlank(lang)) {
             locale = Locale.forLanguageTag(lang);
         } else if (StringUtils.isNotBlank(acceptLanguage)) {
@@ -83,7 +81,8 @@ public class StockFeedEndpoint {
         LocaleContextHolder.setLocale(locale);
         Locale.setDefault(locale);
 
-        List<List<DataField>> records = getRecords(ticker, years, fromDate, toDate, fields, scaling, interpolate, cleanDate);
+        List<List<DataField>> records = getRecords(ticker, years, fromDate, toDate, fields, scaling, interpolate, cleanDate,
+                category);
 
         final StringBuilder sbBody = new StringBuilder();
         String heading = messageSource.getMessage("stock.title", new Object[]{ticker}, locale);

--- a/timeseries-spring-boot-server/src/test/java/com/leonarduk/finance/springboot/StockFeedEndpointTest.java
+++ b/timeseries-spring-boot-server/src/test/java/com/leonarduk/finance/springboot/StockFeedEndpointTest.java
@@ -18,6 +18,7 @@ import java.util.Optional;
 import static org.hamcrest.Matchers.containsString;
 import static org.mockito.ArgumentMatchers.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @WebMvcTest(StockFeedEndpoint.class)
@@ -41,9 +42,29 @@ class StockFeedEndpointTest {
                         .param("fromDate", "2024-01-01")
                         .param("toDate", "2024-01-02")
                         .param("interpolate", "true")
-                        .param("cleanDate", "true"))
+                        .param("cleanDate", "true")
+                        .param("category", "Cash"))
                 .andExpect(status().isOk())
                 .andExpect(content().string(containsString("<html")));
+    }
+
+    @Test
+    void displayHistoryAsJsonFiltersOutNonMatchingCategory() throws Exception {
+        Instrument instrument = Instrument.CASH;
+        StockV1 stock = AbstractStockFeed.createStock(instrument, Collections.emptyList());
+        Mockito.when(stockFeed.get(eq(instrument), eq(LocalDate.parse("2024-01-01")),
+                eq(LocalDate.parse("2024-01-02")), anyBoolean(), anyBoolean(), anyBoolean()))
+                .thenReturn(Optional.of(stock));
+
+        mockMvc.perform(post("/stock/ticker")
+                        .param("ticker", "CASH")
+                        .param("fromDate", "2024-01-01")
+                        .param("toDate", "2024-01-02")
+                        .param("interpolate", "true")
+                        .param("cleanDate", "true")
+                        .param("category", "EQUITY"))
+                .andExpect(status().isOk())
+                .andExpect(content().json("{}"));
     }
 }
 


### PR DESCRIPTION
## Summary
- allow querying by optional instrument category via `category` parameter
- skip instruments whose category doesn't match the provided filter
- document category usage in API docs

## Testing
- `mvn -pl timeseries-spring-boot-server spotless:apply` *(fails: Non-resolvable parent POM)*
- `mvn -pl timeseries-spring-boot-server test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_689ccf39b81c8327afdfbccb8ea38637