### PR TITLE
feat: enforce api key for ticker metadata updates

### DIFF
--- a/timeseries-python/integrations/portfolioperformance/update_missing_tickers.py
+++ b/timeseries-python/integrations/portfolioperformance/update_missing_tickers.py
@@ -55,7 +55,11 @@ def update_missing(xml_file: str, ftse_module_path: str) -> Dict[str, str]:
     ftse_mod = import_module(ftse_module_path)
     mapping: Dict[str, str] = dict(ftse_mod.ftse_all_share)
 
-    client = OpenAI(api_key=os.environ.get("OPENAI_API_KEY"))
+    api_key = os.environ.get("OPENAI_API_KEY")
+    if not api_key:
+        raise RuntimeError("OPENAI_API_KEY environment variable is required")
+
+    client = OpenAI(api_key=api_key)
     updates: Dict[str, str] = {}
 
     for ticker_with_suffix in missing:


### PR DESCRIPTION
## Summary
- ensure `update_missing_tickers` exits early if `OPENAI_API_KEY` is not set

## Testing
- `python -m pytest -q`
- `PYTHONPATH=timeseries-python python -m integrations.portfolioperformance.update_missing_tickers timeseries-python/integrations/portfolioperformance/resources/sample.xml` *(fails: OPENAI_API_KEY environment variable is required)*

------
https://chatgpt.com/codex/tasks/task_e_689ccf29c7348327bc01ad6c436f5b58