### PR TITLE
Add configurable portfolio summary scheduler and email tests

### DIFF
--- a/timeseries-spring-boot-server/src/main/java/com/leonarduk/finance/springboot/service/PortfolioSummaryScheduler.java
+++ b/timeseries-spring-boot-server/src/main/java/com/leonarduk/finance/springboot/service/PortfolioSummaryScheduler.java
@@ -19,9 +19,10 @@ public class PortfolioSummaryScheduler {
     }
 
     /**
-     * Triggered based on cron expression defined in application properties.
+     * Triggered based on cron expression defined in application properties
+     * (`portfolio.summary.cron`).
      */
-    @Scheduled(cron = "${portfolio.summary.cron:0 0 8,18 * * *}")
+    @Scheduled(cron = "${portfolio.summary.cron}")
     public void sendPortfolioSummary() {
         String summary = metricsService.createSummary();
         emailService.send("Portfolio Metrics Summary", summary);

--- a/timeseries-spring-boot-server/src/test/java/com/leonarduk/finance/springboot/service/EmailServiceTest.java
+++ b/timeseries-spring-boot-server/src/test/java/com/leonarduk/finance/springboot/service/EmailServiceTest.java
@@ -1,0 +1,39 @@
+package com.leonarduk.finance.springboot.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.verify;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+
+@ExtendWith(MockitoExtension.class)
+class EmailServiceTest {
+
+    @Mock
+    private JavaMailSender mailSender;
+
+    private EmailService emailService;
+
+    @BeforeEach
+    void setUp() {
+        emailService = new EmailService(mailSender, "recipient@example.com");
+    }
+
+    @Test
+    void sendDelegatesToJavaMailSender() {
+        emailService.send("Subject", "Body");
+
+        ArgumentCaptor<SimpleMailMessage> captor = ArgumentCaptor.forClass(SimpleMailMessage.class);
+        verify(mailSender).send(captor.capture());
+        SimpleMailMessage sent = captor.getValue();
+        assertEquals("recipient@example.com", sent.getTo()[0]);
+        assertEquals("Subject", sent.getSubject());
+        assertEquals("Body", sent.getText());
+    }
+}

--- a/timeseries-spring-boot-server/src/test/java/com/leonarduk/finance/springboot/service/PortfolioSummarySchedulerTest.java
+++ b/timeseries-spring-boot-server/src/test/java/com/leonarduk/finance/springboot/service/PortfolioSummarySchedulerTest.java
@@ -1,0 +1,33 @@
+package com.leonarduk.finance.springboot.service;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class PortfolioSummarySchedulerTest {
+
+    @Mock
+    private PortfolioMetricsService metricsService;
+
+    @Mock
+    private EmailService emailService;
+
+    @InjectMocks
+    private PortfolioSummaryScheduler scheduler;
+
+    @Test
+    void sendPortfolioSummaryDelegatesToServices() {
+        when(metricsService.createSummary()).thenReturn("summary");
+
+        scheduler.sendPortfolioSummary();
+
+        verify(metricsService).createSummary();
+        verify(emailService).send("Portfolio Metrics Summary", "summary");
+    }
+}


### PR DESCRIPTION
## Summary
- Use application property-driven cron expression for the portfolio summary scheduler.
- Introduce unit tests for the scheduler and email service behaviors.

## Testing
- `mvn -q -pl timeseries-spring-boot-server test` *(fails: Non-resolvable parent POM; Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689ccf3895608327bd10f51e5f7cc3b6