### PR TITLE
Use Logback backend instead of Log4j 1.x binding

### DIFF
--- a/timeseries-sources/pom.xml
+++ b/timeseries-sources/pom.xml
@@ -97,11 +97,12 @@
 			<artifactId>htmlunit-driver</artifactId>
 			<version>${org.seleniumhq.selenium.version}</version>
 		</dependency>
-		<dependency>
-			<groupId>org.slf4j</groupId>
-			<artifactId>slf4j-log4j12</artifactId>
-			<version>${org.slf4j.version}</version>
-		</dependency>
+                <!-- Removed legacy SLF4J binding to Log4j 1.x -->
+                <dependency>
+                        <groupId>ch.qos.logback</groupId>
+                        <artifactId>logback-classic</artifactId>
+                        <version>1.4.14</version>
+                </dependency>
 		<dependency>
 			<groupId>org.apache.commons</groupId>
 			<artifactId>commons-lang3</artifactId>


### PR DESCRIPTION
## Summary
- remove legacy `slf4j-log4j12` binding
- add modern `logback-classic` as the SLF4J backend

## Testing
- `mvn -f timeseries-sources/pom.xml -Daws-java-sdk-bom.version=1.12.283 dependency:tree -Dincludes=log4j` *(fails: Non-resolvable import POM: com.amazonaws:aws-java-sdk-bom:pom:1.12.283)*
- `mvn -q -f timeseries-sources/pom.xml -Daws-java-sdk-bom.version=1.12.283 test` *(fails: Non-resolvable import POM: com.amazonaws:aws-java-sdk-bom:pom:1.12.283)*

------
https://chatgpt.com/codex/tasks/task_e_689ccf0f4c60832796dc1aede4719476