### PR TITLE
Use shared ta4j version property

### DIFF
--- a/timeseries-spring-boot-server/pom.xml
+++ b/timeseries-spring-boot-server/pom.xml
@@ -78,11 +78,11 @@
             <scope>compile</scope>
         </dependency>
 		<!-- ta4j -->
-		<dependency>
-			<groupId>org.ta4j</groupId>
-			<artifactId>ta4j-core</artifactId>
-			<version>0.12</version>
-		</dependency>
+                <dependency>
+                        <groupId>org.ta4j</groupId>
+                        <artifactId>ta4j-core</artifactId>
+                        <version>${org.ta4j.version}</version>
+                </dependency>
 		
 
 		<!-- google finance -->


### PR DESCRIPTION
## Summary
- Use `${org.ta4j.version}` property for ta4j-core dependency in timeseries Spring Boot server
- Parent POM already defines `org.ta4j.version` as `0.18`

## Testing
- `mvn -pl timeseries-spring-boot-server -am verify` *(fails: Non-resolvable parent POM: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.5.3)*

------
https://chatgpt.com/codex/tasks/task_e_689cd17653788327a61bb29c575ecd1f