### PR TITLE
Escape HTML in HtmlTools

### DIFF
--- a/timeseries-stockfeed/pom.xml
+++ b/timeseries-stockfeed/pom.xml
@@ -11,4 +11,12 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>timeseries-stockfeed</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-text</artifactId>
+            <version>1.11.0</version>
+        </dependency>
+    </dependencies>
 </project>

--- a/timeseries-stockfeed/src/main/java/com/leonarduk/finance/utils/HtmlTools.java
+++ b/timeseries-stockfeed/src/main/java/com/leonarduk/finance/utils/HtmlTools.java
@@ -1,5 +1,6 @@
 package com.leonarduk.finance.utils;
 
+import org.apache.commons.text.StringEscapeUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -25,7 +26,8 @@ public class HtmlTools {
         }
         sb.append("<td bgcolor='")
                 .append(HtmlTools.getColour(value == null ? "" : value)).append("'>")
-                .append(formatter.format(value == null ? "" : value)).append("</td>");
+                .append(StringEscapeUtils.escapeHtml4(formatter.format(value == null ? "" : value)))
+                .append("</td>");
     }
 
     public static void addHeader(final String nameRaw, final StringBuilder sb) {
@@ -37,7 +39,9 @@ public class HtmlTools {
             name = "";
             HtmlTools.logger.warn(bundle().getString("htmltools.null_field"));
         }
-        sb.append("<th>").append(name).append("</th>");
+        sb.append("<th>")
+                .append(StringEscapeUtils.escapeHtml4(name))
+                .append("</th>");
     }
 
     public static StringBuilder createHtmlText(final StringBuilder sbHead, final StringBuilder sbBody) {

--- a/timeseries-stockfeed/src/main/java/module-info.java
+++ b/timeseries-stockfeed/src/main/java/module-info.java
@@ -13,6 +13,7 @@ module timeseries.stockfeed {
     requires http.request;
     requires influxdb.client.core;
     requires org.apache.commons.lang3;
+    requires org.apache.commons.text;
     requires org.htmlunit;
     requires org.seleniumhq.selenium.api;
     requires org.slf4j;

--- a/timeseries-stockfeed/src/test/java/com/leonarduk/finance/utils/HtmlToolsTest.java
+++ b/timeseries-stockfeed/src/test/java/com/leonarduk/finance/utils/HtmlToolsTest.java
@@ -1,0 +1,23 @@
+package com.leonarduk.finance.utils;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class HtmlToolsTest {
+
+    @Test
+    public void testAddFieldEscapesHtml() {
+        StringBuilder sb = new StringBuilder();
+        String malicious = "<script>alert(1)</script>";
+        HtmlTools.addField(malicious, sb, null);
+        Assert.assertEquals("<td bgcolor='white'>&lt;script&gt;alert(1)&lt;/script&gt;</td>", sb.toString());
+    }
+
+    @Test
+    public void testAddHeaderEscapesHtml() {
+        StringBuilder sb = new StringBuilder();
+        String malicious = "<script>alert(1)</script>";
+        HtmlTools.addHeader(malicious, sb);
+        Assert.assertEquals("<th>&lt;script&gt;alert(1)&lt;/script&gt;</th>", sb.toString());
+    }
+}


### PR DESCRIPTION
## Summary
- escape HTML when rendering table fields and headers using Apache Commons Text
- add Apache Commons Text dependency and expose it in module-info
- test HtmlTools against malicious script injection

## Testing
- `mvn -q -Daws-java-sdk-bom.version=1.12.661 -Djava.net.preferIPv4Stack=true test` *(fails: Non-resolvable import POM: com.amazonaws:aws-java-sdk-bom)*

------
https://chatgpt.com/codex/tasks/task_e_689ccf13f4148327ac7478b7c2ce4f72