### PR TITLE
Enable configurable CORS and verify stock endpoint

### DIFF
--- a/timeseries-spring-boot-server/src/main/java/com/leonarduk/finance/springboot/config/CorsConfig.java
+++ b/timeseries-spring-boot-server/src/main/java/com/leonarduk/finance/springboot/config/CorsConfig.java
@@ -5,6 +5,13 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
+import java.util.Arrays;
+
+/**
+ * Simple CORS configuration that reads the allowed origins from the
+ * {@code cors.allowed-origins} property. Multiple origins can be supplied as a
+ * comma separated list.
+ */
 @Configuration
 public class CorsConfig implements WebMvcConfigurer {
 
@@ -13,7 +20,9 @@ public class CorsConfig implements WebMvcConfigurer {
 
     @Override
     public void addCorsMappings(CorsRegistry registry) {
-        String[] origins = allowedOrigins.split(",");
+        String[] origins = Arrays.stream(allowedOrigins.split(","))
+                .map(String::trim)
+                .toArray(String[]::new);
         registry.addMapping("/**")
                 .allowedOrigins(origins)
                 .allowedMethods("*")

--- a/timeseries-spring-boot-server/src/test/java/com/leonarduk/finance/springboot/StockFeedCorsTest.java
+++ b/timeseries-spring-boot-server/src/test/java/com/leonarduk/finance/springboot/StockFeedCorsTest.java
@@ -1,0 +1,44 @@
+package com.leonarduk.finance.springboot;
+
+import com.leonarduk.finance.springboot.config.CorsConfig;
+import com.leonarduk.finance.stockfeed.StockFeed;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(StockFeedEndpoint.class)
+@Import(CorsConfig.class)
+@TestPropertySource(properties = "cors.allowed-origins=http://example.com")
+class StockFeedCorsTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private StockFeed stockFeed;
+
+    @Test
+    void corsHeadersPresentOnStockEndpoint() throws Exception {
+        Mockito.doReturn(Optional.empty())
+                .when(stockFeed).get(any(), anyInt(), anyBoolean());
+
+        mockMvc.perform(get("/stock/price/CASH")
+                        .header("Origin", "http://example.com"))
+                .andExpect(status().isOk())
+                .andExpect(header().string("Access-Control-Allow-Origin", "http://example.com"));
+    }
+}


### PR DESCRIPTION
## Summary
- configure CORS using `cors.allowed-origins` property in new `CorsConfig`
- trim and apply allowed origins when registering mappings
- add test ensuring `/stock` endpoint includes CORS headers

## Testing
- `mvn -q -pl timeseries-spring-boot-server test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_689ccf352f708327a7c282f01b8cccc2