### PR TITLE
feat: make dividend refresh configurable

### DIFF
--- a/.github/workflows/dividend_refresh.yml
+++ b/.github/workflows/dividend_refresh.yml
@@ -18,7 +18,7 @@ jobs:
         run: |
           pip install yfinance pandas ta scipy matplotlib python-dateutil
       - name: Refresh dividend yields
-        run: python timeseries-python/dividend_refresh.py
+        run: python timeseries-python/dividend_refresh.py --output db/dividend_yields.csv
       - name: Commit updated yields
         run: |
           if [ -n "$(git status --porcelain)" ]; then


### PR DESCRIPTION
## Summary
- extend dividend_refresh CLI to accept tickers and output paths
- wire GitHub Actions job to call script with explicit output file

## Testing
- `python timeseries-python/dividend_refresh.py --ticker VOD.L --output /tmp/test_yields.csv` *(fails: Failed to perform, curl: (56) CONNECT tunnel failed, response 403)*
- `pre-commit run --files timeseries-python/dividend_refresh.py`


------
https://chatgpt.com/codex/tasks/task_e_689ccf2617948327b507926f63aec4e9