### PR TITLE
Explicitly require urllib3>=2.2.0

### DIFF
--- a/timeseries-python/requirements.txt
+++ b/timeseries-python/requirements.txt
@@ -8,7 +8,7 @@ praw~=7.8.1
 textblob
 beautifulsoup4~=4.13.4
 requests~=2.32.3
-urllib3>=2.2.0
+urllib3>=2.2.0  # Explicitly require modern urllib3 for security fixes
 python-dotenv~=1.1.0
 
 numpy~=2.2.5


### PR DESCRIPTION
## Summary
- explicitly require modern urllib3 version in timeseries-python requirements

## Testing
- `pre-commit run --files timeseries-python/requirements.txt`
- `pip install -r timeseries-python/requirements.txt`
- `pytest timeseries-python/tests`


------
https://chatgpt.com/codex/tasks/task_e_689ccf225c2483279b729dc8d36e6e13