### PR TITLE
Prevent duplicate final trading day during interpolation

### DIFF
--- a/timeseries-stockfeed/src/main/java/com/leonarduk/finance/stockfeed/datatransformation/interpolation/AbstractLineInterpolator.java
+++ b/timeseries-stockfeed/src/main/java/com/leonarduk/finance/stockfeed/datatransformation/interpolation/AbstractLineInterpolator.java
@@ -44,15 +44,17 @@ public abstract class AbstractLineInterpolator implements TimeSeriesInterpolator
             List<Bar> tail = Lists.newArrayList(lastQuote,
                     this.calculateFutureValue(lastQuote, toLocalDate));
 
-            // interpolate the tail range and remove the boundary entries which
+            // interpolate the tail range and remove any boundary entries which
             // simply duplicate the last known value
             List<Bar> extended = interpolateRange(tail, lastDateInSeries,
                     toLocalDate);
             if (!extended.isEmpty()) {
                 extended.remove(extended.size() - 1); // drop placeholder
-            }
-            if (!extended.isEmpty()) {
-                extended.remove(0); // drop duplicated last quote
+                // Drop the previous trading day only if it has been reinserted
+                if (!extended.isEmpty()
+                        && extended.get(0).getEndTime().toLocalDate().isEqual(lastDateInSeries)) {
+                    extended.remove(0);
+                }
             }
 
             series.addAll(extended);

--- a/timeseries-stockfeed/src/test/java/com/leonarduk/finance/stockfeed/interpolation/FlatLineInterpolatorTest.java
+++ b/timeseries-stockfeed/src/test/java/com/leonarduk/finance/stockfeed/interpolation/FlatLineInterpolatorTest.java
@@ -4,6 +4,7 @@ import com.leonarduk.finance.stockfeed.Instrument;
 import com.leonarduk.finance.stockfeed.datatransformation.interpolation.FlatLineInterpolator;
 import com.leonarduk.finance.stockfeed.datatransformation.interpolation.TimeSeriesInterpolator;
 import com.leonarduk.finance.stockfeed.feed.ExtendedHistoricalQuote;
+import com.leonarduk.finance.utils.TimeseriesUtils;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -52,7 +53,7 @@ public class FlatLineInterpolatorTest {
     }
 
     @Test
-    public void testExtendToToDateSkipsFinalDuplicate() throws Exception {
+    public void testExtendToToDateDoesNotDuplicateFinalDate() throws Exception {
         List<ExtendedHistoricalQuote> quotes = Arrays.asList(
                 new ExtendedHistoricalQuote(Instrument.UNKNOWN, LocalDate.parse("2017-04-07"), 100.0,
                         112.0, 92.0, 102.0, 5000.0, 0, ""),
@@ -61,13 +62,18 @@ public class FlatLineInterpolatorTest {
 
         List<Bar> base = quotes.stream().map(ExtendedHistoricalQuote::new)
                 .collect(Collectors.toList());
+        base.sort(TimeseriesUtils.getComparator());
 
         List<Bar> extended = new FlatLineInterpolator().extendToToDate(base,
                 LocalDate.parse("2017-04-14"));
 
+        LocalDate lastDate = extended.get(extended.size() - 1).getEndTime().toLocalDate();
+
         Assert.assertEquals(6, extended.size());
-        Assert.assertEquals(LocalDate.parse("2017-04-13"),
-                extended.get(extended.size() - 1).getEndTime().toLocalDate());
+        Assert.assertEquals(LocalDate.parse("2017-04-13"), lastDate);
+        long occurrences = extended.stream()
+                .filter(bar -> bar.getEndTime().toLocalDate().isEqual(lastDate)).count();
+        Assert.assertEquals(1, occurrences);
     }
 
 }


### PR DESCRIPTION
## Summary
- Ensure forward interpolation drops any reinserted final trading day
- Add regression test confirming final interpolated date occurs only once

## Testing
- `mvn -q -pl timeseries-stockfeed test` *(fails: Non-resolvable parent POM for com.leonarduk:timeseries-spring-boot-server ... Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689cd177641c83279c46b30445933110