### PR TITLE
Document lambda environment variables and add session token placeholder

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ environment variables:
 
 * `AWS_ACCESS_KEY_ID` – AWS access key used for authentication.
 * `AWS_SECRET_ACCESS_KEY` – AWS secret key paired with the access key.
+* `AWS_SESSION_TOKEN` – Temporary session token when using short-lived credentials.
 * `AWS_REGION` – AWS region containing your resources.
 * `SQS_QUEUE_URL` – URL of the SQS queue feeding the Lambda handler.
 
@@ -65,6 +66,7 @@ Run the image with the variables passed via `docker run`:
 docker run \
   -e AWS_ACCESS_KEY_ID=your_access_key \
   -e AWS_SECRET_ACCESS_KEY=your_secret_key \
+  -e AWS_SESSION_TOKEN=your_session_token \
   -e AWS_REGION=eu-west-1 \
   -e SQS_QUEUE_URL=https://sqs.eu-west-1.amazonaws.com/123456789012/queue \
   <image>

--- a/timeseries-lambda/Dockerfile
+++ b/timeseries-lambda/Dockerfile
@@ -3,6 +3,7 @@ FROM openjdk:18-jdk
 # Placeholder environment variables for AWS credentials and SQS configuration
 ENV AWS_ACCESS_KEY_ID="" \
     AWS_SECRET_ACCESS_KEY="" \
+    AWS_SESSION_TOKEN="" \
     AWS_REGION="" \
     SQS_QUEUE_URL=""
 


### PR DESCRIPTION
## Summary
- expose AWS_SESSION_TOKEN placeholder in timeseries-lambda Dockerfile
- document required environment variables and docker run usage

## Testing
- `pre-commit run --files README.md timeseries-lambda/Dockerfile`
- `mvn test -pl timeseries-lambda -am` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689ccf31805883279a81e884bbc290d3