### PR TITLE
Add max drawdown analysis and endpoint

### DIFF
--- a/timeseries-python/analysis/max_drawdown.py
+++ b/timeseries-python/analysis/max_drawdown.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from typing import Iterable, Union
+
+import numpy as np
+import pandas as pd
+
+from .portfolio.timeseries_api import get_time_series
+
+
+def max_drawdown(ticker: Union[str, Iterable[str]], years: int = 5) -> pd.DataFrame:
+    """Calculate the maximum drawdown for each ticker.
+
+    Args:
+        ticker: Single ticker or iterable of tickers.
+        years: Number of years of price history to request.
+
+    Returns:
+        DataFrame with columns ``ticker`` and ``max_drawdown`` (as a positive
+        fraction).
+    """
+
+    tickers = [ticker] if isinstance(ticker, str) else list(ticker)
+    prices = get_time_series(ticker=tickers, years=years)
+    if prices.empty:
+        return pd.DataFrame(columns=["ticker", "max_drawdown"])
+
+    drawdowns: dict[str, float] = {}
+    for t in tickers:
+        series = prices[t].dropna()
+        if series.empty:
+            drawdowns[t] = np.nan
+            continue
+        running_max = series.cummax()
+        drawdown_series = series / running_max - 1
+        drawdowns[t] = abs(drawdown_series.min())
+
+    return pd.DataFrame({"ticker": list(drawdowns.keys()), "max_drawdown": list(drawdowns.values())})

--- a/timeseries-python/analysis/risk_return_api.py
+++ b/timeseries-python/analysis/risk_return_api.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from flask import Flask, jsonify, render_template, request
 
 from .risk_return import risk_return
+from .max_drawdown import max_drawdown
 
 app = Flask(__name__, template_folder="templates")
 
@@ -20,6 +21,21 @@ def risk_return_endpoint():
 @app.route("/analytics/risk-return/ui")
 def risk_return_ui():
     return render_template("risk_return.html")
+
+
+@app.route("/analytics/max-drawdown")
+def max_drawdown_endpoint():
+    tickers = request.args.get("tickers")
+    if not tickers:
+        return jsonify([])
+    ticker_list = [t.strip() for t in tickers.split(",") if t.strip()]
+    data = max_drawdown(ticker_list)
+    return jsonify(data.to_dict(orient="records"))
+
+
+@app.route("/analytics/max-drawdown/ui")
+def max_drawdown_ui():
+    return render_template("max_drawdown.html")
 
 
 if __name__ == "__main__":

--- a/timeseries-python/analysis/templates/max_drawdown.html
+++ b/timeseries-python/analysis/templates/max_drawdown.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8" />
+    <title>Max Drawdown</title>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+</head>
+<body>
+<canvas id="maxDrawdownChart" width="400" height="300"></canvas>
+<script>
+fetch('/analytics/max-drawdown?tickers=AAPL,MSFT')
+  .then(res => res.json())
+  .then(data => {
+      const ctx = document.getElementById('maxDrawdownChart').getContext('2d');
+      new Chart(ctx, {
+        type: 'bar',
+        data: {
+          labels: data.map(d => d.ticker),
+          datasets: [{
+            label: 'Max Drawdown',
+            data: data.map(d => d.max_drawdown),
+            backgroundColor: 'rgba(255, 99, 132, 0.6)'
+          }]
+        },
+        options: {
+          scales: {
+            y: {
+              title: { display: true, text: 'Max Drawdown' },
+              ticks: { callback: v => (v * 100).toFixed(2) + '%' }
+            }
+          }
+        }
+      });
+  });
+</script>
+</body>
+</html>

--- a/timeseries-python/tests/test_max_drawdown.py
+++ b/timeseries-python/tests/test_max_drawdown.py
@@ -1,0 +1,13 @@
+import pandas as pd
+import pytest
+from unittest.mock import patch
+
+from analysis.max_drawdown import max_drawdown
+
+
+def test_max_drawdown_calculates_metric():
+    prices = pd.DataFrame({"AAPL": [100, 120, 90, 130]}, index=pd.date_range("2024-01-01", periods=4))
+    with patch("analysis.max_drawdown.get_time_series", return_value=prices):
+        result = max_drawdown("AAPL", years=1)
+    assert result.loc[0, "ticker"] == "AAPL"
+    assert result.loc[0, "max_drawdown"] == pytest.approx(0.25)


### PR DESCRIPTION
## Summary
- add max drawdown risk metric calculation
- expose max drawdown via REST endpoint and demo UI chart
- test max drawdown calculation with sample data

## Testing
- `cd timeseries-python && pytest >/tmp/pytest.log && tail -n 20 /tmp/pytest.log`


------
https://chatgpt.com/codex/tasks/task_e_689ccf3b87088327a562911c4ced0bec