### PR TITLE
Filter out inactive instruments from loader

### DIFF
--- a/timeseries-stockfeed/src/test/java/com/leonarduk/finance/stockfeed/InstrumentTest.java
+++ b/timeseries-stockfeed/src/test/java/com/leonarduk/finance/stockfeed/InstrumentTest.java
@@ -48,9 +48,17 @@ public class InstrumentTest {
     @Test
     public void testInactiveTickerFilteredOut() throws IOException {
         Instrument.InstrumentLoader loader = Instrument.InstrumentLoader.getInstance();
+        // Inactive instrument CC1 should not be present using any of its identifiers
         Assert.assertFalse(loader.getInstruments().containsKey("CC1"));
+        Assert.assertFalse(loader.getInstruments().containsKey("FR0010713784"));
+        Assert.assertFalse(loader.getInstruments().containsKey("LON:CC1"));
+
+        // Active instrument still available
         Assert.assertTrue(loader.getInstruments().containsKey("XDND"));
+
+        // Lookups for inactive identifiers should return a manually created placeholder
         Assert.assertEquals(Source.MANUAL, Instrument.fromString("CC1").getSource());
+        Assert.assertEquals(Source.MANUAL, Instrument.fromString("FR0010713784").getSource());
     }
 
 }


### PR DESCRIPTION
## Summary
- load `Instrument` active flag from CSV and only retain active instruments
- expose unmodifiable map of active instruments
- test that inactive tickers and identifiers are filtered out

## Testing
- `mvn -q -pl timeseries-stockfeed test` *(fails: Could not transfer artifacts from Maven Central)*
- `mvn -q -pl timeseries-stockfeed -o test` *(fails: Cannot access central in offline mode)*

------
https://chatgpt.com/codex/tasks/task_e_689ccf24e5d48327b9e7e1de800ede91