### PR TITLE
Ensure InstrumentLoader initializes only once and add singleton test

### DIFF
--- a/timeseries-stockfeed/src/main/java/com/leonarduk/finance/stockfeed/Instrument.java
+++ b/timeseries-stockfeed/src/main/java/com/leonarduk/finance/stockfeed/Instrument.java
@@ -74,21 +74,23 @@ public sealed class Instrument permits FxInstrument {
     public static class InstrumentLoader {
         private Map<String, Instrument> instruments = null;
 
-        private static InstrumentLoader instance;
+        private static volatile InstrumentLoader instance;
 
         public static InstrumentLoader getInstance() throws IOException {
-//			if (InstrumentLoader.instance == null) {
-            InstrumentLoader.instance = new InstrumentLoader();
-
-            try {
-                instance.init("resources/data/instruments_list.csv");
-            } catch (URISyntaxException e) {
-                // TODO Auto-generated catch block
-                throw new IOException(e);
+            if (instance == null) {
+                synchronized (InstrumentLoader.class) {
+                    if (instance == null) {
+                        InstrumentLoader loader = new InstrumentLoader();
+                        try {
+                            loader.init("resources/data/instruments_list.csv");
+                        } catch (URISyntaxException e) {
+                            throw new IOException(e);
+                        }
+                        instance = loader;
+                    }
+                }
             }
-//			}
-
-            return InstrumentLoader.instance;
+            return instance;
         }
 
         private final static Logger logger = LoggerFactory.getLogger(Instrument.class.getName());


### PR DESCRIPTION
## Summary
- Reinstate null check and make InstrumentLoader.getInstance thread-safe with double-checked locking
- Add unit test verifying InstrumentLoader reads CSV once and returns same reference

## Testing
- `mvn -q -pl timeseries-stockfeed test` *(fails: Non-resolvable parent POM; network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689ce13e532483278cf09187beaf9dc1