### PR TITLE
Verify ExtendedStockQuote fields before marking as populated

### DIFF
--- a/timeseries-stockfeed/src/main/java/com/leonarduk/finance/stockfeed/feed/yahoofinance/ExtendedStockQuote.java
+++ b/timeseries-stockfeed/src/main/java/com/leonarduk/finance/stockfeed/feed/yahoofinance/ExtendedStockQuote.java
@@ -61,8 +61,7 @@ public class ExtendedStockQuote extends StockQuote {
     }
 
     public boolean isPopulated() {
-        // TODO Auto-generated method stub
-        return true;
+        return getPrice() != null && getOpen() != null && getPreviousClose() != null;
     }
 
 }

--- a/timeseries-stockfeed/src/test/java/com/leonarduk/finance/stockfeed/feed/yahoofinance/ExtendedStockQuoteTest.java
+++ b/timeseries-stockfeed/src/test/java/com/leonarduk/finance/stockfeed/feed/yahoofinance/ExtendedStockQuoteTest.java
@@ -1,0 +1,28 @@
+package com.leonarduk.finance.stockfeed.feed.yahoofinance;
+
+import com.leonarduk.finance.stockfeed.Instrument;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.math.BigDecimal;
+
+public class ExtendedStockQuoteTest {
+
+    @Test
+    public void isPopulatedReturnsTrueWhenFieldsPresent() {
+        ExtendedStockQuote quote = new ExtendedStockQuote(
+                null, null, null, null, null, null, null, Instrument.UNKNOWN, null, null,
+                null, null, BigDecimal.ONE, BigDecimal.TEN, BigDecimal.valueOf(100), null, null,
+                null, null, null, null);
+        Assert.assertTrue(quote.isPopulated());
+    }
+
+    @Test
+    public void isPopulatedReturnsFalseWhenFieldsMissing() {
+        ExtendedStockQuote quote = new ExtendedStockQuote(
+                null, null, null, null, null, null, null, Instrument.UNKNOWN, null, null,
+                null, null, null, null, null, null, null,
+                null, null, null, null);
+        Assert.assertFalse(quote.isPopulated());
+    }
+}


### PR DESCRIPTION
## Summary
- Require price, open, and previous close to be present for `ExtendedStockQuote.isPopulated`
- Add unit tests covering populated and empty quotes

## Testing
- `mvn -q -f timeseries-stockfeed/pom.xml test` *(fails: Non-resolvable import POM; network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689ce139db7c832799af49d1bd672021