### PR TITLE
Ensure ticker parameter is mandatory

### DIFF
--- a/timeseries-lambda/src/main/java/com/leonarduk/aws/QueryRunner.java
+++ b/timeseries-lambda/src/main/java/com/leonarduk/aws/QueryRunner.java
@@ -54,10 +54,11 @@ public class QueryRunner {
      *
      * @param inputParams a map containing the parameters such as ticker, years, months, weeks, days,
      *                    fromDate, toDate, interpolate, cleanData, region, type, and currency.
-     *                    The map should contain at least the 'ticker' key.
+     *                    <strong>The map must include the {@code ticker} key.</strong>
      * @return a String representing the generated results in HTML format.
      * @throws IOException if an IO error occurs during the retrieval of results.
-     * @throws IllegalArgumentException if the inputParams map is null or does not contain the 'ticker' key.
+     * @throws IllegalArgumentException if the {@code inputParams} map is {@code null} or missing the required
+     *                                  {@code ticker} key.
      */
     public String getResults(Map<String, String> inputParams) throws IOException {
 
@@ -66,6 +67,10 @@ public class QueryRunner {
             throw new IllegalArgumentException("No parameters provided. Expect at least ticker");
         }
         log.debug("Input parameters: {}", inputParams);
+
+        if (!inputParams.containsKey(TICKER) || StringUtils.isBlank(inputParams.get(TICKER))) {
+            throw new IllegalArgumentException("Ticker parameter is required");
+        }
 
 
         String ticker = inputParams.get(TICKER);

--- a/timeseries-lambda/src/test/java/com/leonarduk/aws/QueryRunnerTest.java
+++ b/timeseries-lambda/src/test/java/com/leonarduk/aws/QueryRunnerTest.java
@@ -1,0 +1,18 @@
+package com.leonarduk.aws;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class QueryRunnerTest {
+
+    @Test
+    void getResultsThrowsWhenTickerMissing() {
+        QueryRunner runner = new QueryRunner();
+        Map<String, String> params = new HashMap<>();
+        assertThrows(IllegalArgumentException.class, () -> runner.getResults(params));
+    }
+}


### PR DESCRIPTION
## Summary
- enforce presence of ticker parameter in `QueryRunner.getResults` and document the requirement
- add unit test verifying `getResults` throws `IllegalArgumentException` when ticker is missing

## Testing
- `mvn -q -pl timeseries-lambda -am test` *(fails: Non-resolvable parent POM... Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689ce137a94883278674f3da0a604f84