### PR TITLE
Filter FT timeseries by date range

### DIFF
--- a/timeseries-stockfeed/src/test/java/com/leonarduk/finance/stockfeed/feed/ft/FTTimeSeriesPageTest.java
+++ b/timeseries-stockfeed/src/test/java/com/leonarduk/finance/stockfeed/feed/ft/FTTimeSeriesPageTest.java
@@ -1,0 +1,50 @@
+package com.leonarduk.finance.stockfeed.feed.ft;
+
+import com.leonarduk.finance.stockfeed.Instrument;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.htmlunit.HtmlUnitDriver;
+import org.ta4j.core.Bar;
+
+import java.net.URL;
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.junit.Assert.*;
+
+public class FTTimeSeriesPageTest {
+
+    private WebDriver webDriver;
+
+    @Before
+    public void setUp() {
+        webDriver = new HtmlUnitDriver();
+    }
+
+    @After
+    public void tearDown() {
+        webDriver.quit();
+    }
+
+    @Test
+    public void getTimeseriesFiltersByDateRange() throws Exception {
+        URL resource = getClass().getResource("/ft_timeseries_sample.html");
+        assertNotNull("Sample data should be available", resource);
+
+        FTTimeSeriesPage page = new FTTimeSeriesPage(webDriver, resource.toString());
+        Instrument instrument = Instrument.fromString("PHGP");
+        LocalDate from = LocalDate.of(2021, 7, 1);
+        LocalDate to = LocalDate.of(2021, 8, 31);
+
+        List<Bar> bars = page.getTimeseries(instrument, from, to);
+
+        assertEquals(2, bars.size());
+        for (Bar bar : bars) {
+            LocalDate date = bar.getEndTime().toLocalDate();
+            assertFalse(date.isBefore(from));
+            assertFalse(date.isAfter(to));
+        }
+    }
+}

--- a/timeseries-stockfeed/src/test/resources/ft_timeseries_sample.html
+++ b/timeseries-stockfeed/src/test/resources/ft_timeseries_sample.html
@@ -1,0 +1,28 @@
+<table class="mod-tearsheet-historical-prices__results">
+  <tbody>
+    <tr>
+      <td><span></span><span>Fri, Aug 20, 2021</span></td>
+      <td>100</td>
+      <td>110</td>
+      <td>90</td>
+      <td>105</td>
+      <td><span></span><span>1000</span></td>
+    </tr>
+    <tr>
+      <td><span></span><span>Sat, Jul 10, 2021</span></td>
+      <td>101</td>
+      <td>111</td>
+      <td>91</td>
+      <td>106</td>
+      <td><span></span><span>1001</span></td>
+    </tr>
+    <tr>
+      <td><span></span><span>Tue, Jun 1, 2021</span></td>
+      <td>102</td>
+      <td>112</td>
+      <td>92</td>
+      <td>107</td>
+      <td><span></span><span>1002</span></td>
+    </tr>
+  </tbody>
+</table>


### PR DESCRIPTION
## Summary
- Pass start and end dates to FT timeseries URL and filter out-of-range rows
- Add Selenium test ensuring only rows within date range are returned

## Testing
- `mvn -q -pl timeseries-stockfeed test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689ce13b70188327a2b50cb40d101359