### PR TITLE
Cache StockFeed instance in DependencyFactory

### DIFF
--- a/timeseries-lambda/src/main/java/com/leonarduk/aws/DependencyFactory.java
+++ b/timeseries-lambda/src/main/java/com/leonarduk/aws/DependencyFactory.java
@@ -9,6 +9,7 @@ public class DependencyFactory {
     private DependencyFactory() {
     }
 
+    private static volatile StockFeed instance;
 
     /**
      * Return an instance of a stock feed. This is a singleton, so subsequent calls will return the same instance.
@@ -16,7 +17,18 @@ public class DependencyFactory {
      * @return A stock feed
      */
     public static StockFeed stockFeed() {
-        return new IntelligentStockFeed(new S3DataStore("timeseries-leonarduk",
-                "timeseries", Region.EU_WEST_1.toString()));
+        if (instance == null) {
+            synchronized (DependencyFactory.class) {
+                if (instance == null) {
+                    instance =
+                            new IntelligentStockFeed(
+                                    new S3DataStore(
+                                            "timeseries-leonarduk",
+                                            "timeseries",
+                                            Region.EU_WEST_1.toString()));
+                }
+            }
+        }
+        return instance;
     }
 }

--- a/timeseries-lambda/src/test/java/com/leonarduk/aws/DependencyFactoryTest.java
+++ b/timeseries-lambda/src/test/java/com/leonarduk/aws/DependencyFactoryTest.java
@@ -1,0 +1,14 @@
+package com.leonarduk.aws;
+
+import com.leonarduk.finance.stockfeed.StockFeed;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class DependencyFactoryTest {
+    @Test
+    void stockFeedReturnsSingleton() {
+        StockFeed first = DependencyFactory.stockFeed();
+        StockFeed second = DependencyFactory.stockFeed();
+        Assertions.assertSame(first, second);
+    }
+}


### PR DESCRIPTION
## Summary
- cache StockFeed instance in DependencyFactory using double-checked locking
- add unit test verifying singleton behavior

## Testing
- `mvn -q -pl timeseries-lambda -am test` *(fails: Non-resolvable parent POM ... network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689ce13866fc8327b5e06e3834031162