### PR TITLE
chore: bump logback to 1.5.18

### DIFF
--- a/timeseries-sources/pom.xml
+++ b/timeseries-sources/pom.xml
@@ -110,7 +110,7 @@
                 <dependency>
                         <groupId>ch.qos.logback</groupId>
                         <artifactId>logback-classic</artifactId>
-                        <version>1.4.14</version>
+                        <version>1.5.18</version>
                 </dependency>
 		<dependency>
 			<groupId>org.apache.commons</groupId>


### PR DESCRIPTION
## Summary
- update logback-classic to 1.5.18 to resolve Dependabot alert #136

## Testing
- `mvn -q -pl timeseries-sources -e -ntp test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689cf18a34b4832792c90b4dbb3c3de1