### PR TITLE
Configure Retrofit base URLs and network security

### DIFF
--- a/android-app/app/build.gradle
+++ b/android-app/app/build.gradle
@@ -15,6 +15,21 @@ android {
         versionName "1.0"
     }
 
+    buildFeatures {
+        buildConfig true
+    }
+
+    buildTypes {
+        debug {
+            buildConfigField "String", "BASE_URL", "\"http://10.0.2.2:8080/\""
+            manifestPlaceholders = [usesCleartextTraffic:"true"]
+        }
+        release {
+            buildConfigField "String", "BASE_URL", "\"https://api.example.com/\""
+            manifestPlaceholders = [usesCleartextTraffic:"false"]
+        }
+    }
+
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_17
         targetCompatibility JavaVersion.VERSION_17

--- a/android-app/app/src/debug/res/xml/network_security_config.xml
+++ b/android-app/app/src/debug/res/xml/network_security_config.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+    <domain-config cleartextTrafficPermitted="true">
+        <domain includeSubdomains="true">10.0.2.2</domain>
+    </domain-config>
+</network-security-config>

--- a/android-app/app/src/main/AndroidManifest.xml
+++ b/android-app/app/src/main/AndroidManifest.xml
@@ -3,7 +3,9 @@
         android:allowBackup="true"
         android:label="@string/app_name"
         android:supportsRtl="true"
-        android:theme="@style/Theme.StockApp">
+        android:theme="@style/Theme.StockApp"
+        android:usesCleartextTraffic="${usesCleartextTraffic}"
+        android:networkSecurityConfig="@xml/network_security_config">
         <activity
             android:name=".MainActivity"
             android:exported="true">

--- a/android-app/app/src/main/java/com/example/stockapp/api/RetrofitClient.kt
+++ b/android-app/app/src/main/java/com/example/stockapp/api/RetrofitClient.kt
@@ -1,14 +1,13 @@
 package com.example.stockapp.api
 
+import com.example.stockapp.BuildConfig
 import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
 
 object RetrofitClient {
-    private const val BASE_URL = "http://10.0.2.2:8080/"
-
     val instance: Retrofit by lazy {
         Retrofit.Builder()
-            .baseUrl(BASE_URL)
+            .baseUrl(BuildConfig.BASE_URL)
             .addConverterFactory(GsonConverterFactory.create())
             .build()
     }

--- a/android-app/app/src/main/res/xml/network_security_config.xml
+++ b/android-app/app/src/main/res/xml/network_security_config.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+    <base-config cleartextTrafficPermitted="false" />
+</network-security-config>


### PR DESCRIPTION
## Summary
- Use BuildConfig to supply base URL and switch between debug (http://10.0.2.2:8080/) and production (https://api.example.com/) endpoints.
- Declare build-time configuration and manifest placeholders to toggle cleartext traffic per build type.
- Add network security configs that block cleartext by default and allow local development traffic only for debug builds.

## Testing
- `gradle build` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689cf413bc6483279feef4eb9f43aff8