### PR TITLE
Disable Android backups and document policy

### DIFF
--- a/android-app/README.md
+++ b/android-app/README.md
@@ -1,0 +1,10 @@
+# Android App
+
+## Backup Policy
+
+The application disables Android's automatic backup feature
+(`android:allowBackup="false"`) to avoid uploading sensitive
+financial information to external storage or cloud services. If backups
+are required in the future, ensure that any data written to disk is
+encrypted or explicitly excluded via a `fullBackupContent` rules file.
+

--- a/android-app/app/src/main/AndroidManifest.xml
+++ b/android-app/app/src/main/AndroidManifest.xml
@@ -1,6 +1,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <!-- Backups are disabled to prevent exposure of sensitive financial data. -->
     <application
-        android:allowBackup="true"
+        android:allowBackup="false"
         android:label="@string/app_name"
         android:supportsRtl="true"
         android:theme="@style/Theme.StockApp">


### PR DESCRIPTION
## Summary
- disable Android backups to avoid leaking financial data
- document rationale for disabling automatic backups

## Testing
- `pre-commit run --files android-app/app/src/main/AndroidManifest.xml android-app/README.md`
- `cd android-app && ./gradlew assembleDebug` *(fails: Unable to access jarfile gradle/wrapper/gradle-wrapper.jar)*

------
https://chatgpt.com/codex/tasks/task_e_689cf4105d908327b6106f4676a2ff71