### PR TITLE
Restrict default CORS origins

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,14 @@ This returns JSON similar to:
 {"close": 123.45}
 ```
 
+### CORS configuration
+
+Cross origin requests are controlled with the `cors.allowed-origins` property. The
+default is empty, meaning no origins are permitted. Provide a comma separated list
+of trusted origins in `application.properties` or override it at runtime using the
+`CORS_ALLOWED_ORIGINS` environment variable. Profile specific files such as
+`application-prod.properties` can also define the property for different environments.
+
 ## timeseries-lambda
 
 The `timeseries-lambda` module runs as a Docker container and requires several

--- a/timeseries-spring-boot-server/src/main/java/com/leonarduk/finance/springboot/config/CorsConfig.java
+++ b/timeseries-spring-boot-server/src/main/java/com/leonarduk/finance/springboot/config/CorsConfig.java
@@ -10,19 +10,22 @@ import java.util.Arrays;
 /**
  * Simple CORS configuration that reads the allowed origins from the
  * {@code cors.allowed-origins} property. Multiple origins can be supplied as a
- * comma separated list.
+ * comma separated list. If the property is not set then no cross origin
+ * requests are allowed.
  */
 @Configuration
 public class CorsConfig implements WebMvcConfigurer {
 
-    @Value("${cors.allowed-origins:*}")
+    @Value("${cors.allowed-origins:}")
     private String allowedOrigins;
 
     @Override
     public void addCorsMappings(CorsRegistry registry) {
-        String[] origins = Arrays.stream(allowedOrigins.split(","))
-                .map(String::trim)
-                .toArray(String[]::new);
+        String[] origins =
+                Arrays.stream(allowedOrigins.split(","))
+                        .map(String::trim)
+                        .filter(s -> !s.isEmpty())
+                        .toArray(String[]::new);
         registry.addMapping("/**")
                 .allowedOrigins(origins)
                 .allowedMethods("*")

--- a/timeseries-spring-boot-server/src/main/resources/application.properties
+++ b/timeseries-spring-boot-server/src/main/resources/application.properties
@@ -6,4 +6,5 @@ spring.mail.host=localhost
 spring.mail.port=25
 
 # Allowed CORS origins
-cors.allowed-origins=*
+# Comma separated list of trusted domains; leave blank to disallow cross origin requests
+cors.allowed-origins=https://example.com


### PR DESCRIPTION
## Summary
- Default to no CORS origins unless explicitly configured
- Example trusted origin in application.properties
- Document environment/profile overrides for CORS

## Testing
- `mvn -q -pl timeseries-spring-boot-server -am verify` *(fails: Non-resolvable parent POM for com.leonarduk:timeseries-spring-boot-server:0.1.1)*

------
https://chatgpt.com/codex/tasks/task_e_689cf41740fc83279b271ef5ae26e28e