### PR TITLE
feat: make finnhub api key configurable

### DIFF
--- a/timeseries-python/integrations/finnhub/README.md
+++ b/timeseries-python/integrations/finnhub/README.md
@@ -1,0 +1,22 @@
+# Finnhub Integration
+
+Scripts in this directory interact with the [Finnhub](https://finnhub.io) API.
+An API key is required and can be supplied in one of two ways:
+
+1. **Environment variable**
+   ```bash
+   export FINNHUB_API_KEY=your_key_here
+   ```
+2. **Configuration file**
+   Create a file named `finnhub.cfg` alongside these scripts containing:
+   ```ini
+   [finnhub]
+   api_key=your_key_here
+   ```
+
+`instrument.py` and `instrument_create.py` will automatically load the key
+using this logic. After configuration you can run the example search:
+
+```bash
+python instrument.py
+```

--- a/timeseries-python/integrations/finnhub/config.py
+++ b/timeseries-python/integrations/finnhub/config.py
@@ -1,0 +1,22 @@
+import os
+from configparser import ConfigParser
+from pathlib import Path
+
+
+def load_api_key() -> str:
+    """Retrieve Finnhub API key from environment or local config file."""
+    api_key = os.getenv("FINNHUB_API_KEY")
+    if api_key:
+        return api_key
+
+    config_path = Path(__file__).with_name("finnhub.cfg")
+    if config_path.exists():
+        config = ConfigParser()
+        config.read(config_path)
+        api_key = config.get("finnhub", "api_key", fallback=None)
+        if api_key:
+            return api_key
+
+    raise EnvironmentError(
+        "Finnhub API key not found. Set FINNHUB_API_KEY or create finnhub.cfg"
+    )

--- a/timeseries-python/integrations/finnhub/instrument.py
+++ b/timeseries-python/integrations/finnhub/instrument.py
@@ -1,7 +1,9 @@
 import finnhub
 
+from .config import load_api_key
+
 # Setup client
-finnhub_client = finnhub.Client(api_key="btjtt2v48v6vivbnrcf0")
+finnhub_client = finnhub.Client(api_key=load_api_key())
 
 # Search for instrument by name
 res = finnhub_client.symbol_lookup("Aviva")

--- a/timeseries-python/integrations/finnhub/instrument_create.py
+++ b/timeseries-python/integrations/finnhub/instrument_create.py
@@ -1,7 +1,10 @@
 import json
 import os
 from datetime import datetime
+
 import finnhub
+
+from .config import load_api_key
 
 
 def create_instrument_from_finnhub(result, xml_file: str, output_file: str):
@@ -39,11 +42,7 @@ def create_instrument_from_finnhub(result, xml_file: str, output_file: str):
 
 
 if __name__ == "__main__":
-    FINNHUB_API_KEY = os.getenv("FINNHUB_API_KEY")
-    if not FINNHUB_API_KEY:
-        raise EnvironmentError("Please set the FINNHUB_API_KEY environment variable.")
-
-    client = finnhub.Client(api_key=FINNHUB_API_KEY)
+    client = finnhub.Client(api_key=load_api_key())
 
     xml_file = "C:/Users/steph/workspaces/luk/data/portfolio/investments-with-id.xml"
     output_file = (


### PR DESCRIPTION
## Summary
- load Finnhub API key from `FINNHUB_API_KEY` env var or `finnhub.cfg`
- document Finnhub configuration and examples
- use shared loader in Finnhub scripts

## Testing
- `pre-commit run --files timeseries-python/integrations/finnhub/instrument.py timeseries-python/integrations/finnhub/instrument_create.py timeseries-python/integrations/finnhub/config.py`


------
https://chatgpt.com/codex/tasks/task_e_689cf41b5e708327a632097c448622d0