### PR TITLE
Specify TA4J dependency version

### DIFF
--- a/timeseries-spring-boot-server/pom.xml
+++ b/timeseries-spring-boot-server/pom.xml
@@ -27,6 +27,7 @@
 		<maven.compiler.target>21</maven.compiler.target>
 		<jacoco.version>0.8.13</jacoco.version>
 		<jahoo.finance.version>3.15.0</jahoo.finance.version>
+		<org.ta4j.version>0.18</org.ta4j.version>
 	</properties>
 
         <repositories>


### PR DESCRIPTION
## Summary
- define `org.ta4j.version` property in timeseries-spring-boot-server to resolve TA4J dependency

## Testing
- `pre-commit run --files timeseries-spring-boot-server/pom.xml`
- `mvn -Djava.net.preferIPv4Stack=true -pl timeseries-spring-boot-server install` *(fails: Could not transfer artifacts from Maven Central - Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689cfecf7b2083279541ba151badc81a