### PR TITLE
Fix AlphaVantage4J dependency via JitPack

### DIFF
--- a/timeseries-sources/pom.xml
+++ b/timeseries-sources/pom.xml
@@ -24,7 +24,7 @@
                 <org.ta4j.version>0.18</org.ta4j.version>
                 <org.jfree.version>3.4.4</org.jfree.version>
                 <org.apache.xmlgraphics.version>1.19</org.apache.xmlgraphics.version>
-                <alphavantage4j.version>1.5.0</alphavantage4j.version>
+                <alphavantage4j.version>v1.5.0</alphavantage4j.version>
                 <yahoofinanceapi.version>3.17.0</yahoofinanceapi.version>
                 <aws-java-sdk-bom.version>1.12.788</aws-java-sdk-bom.version>
         </properties>
@@ -33,6 +33,10 @@
                 <repository>
                         <id>central</id>
                         <url>https://repo1.maven.org/maven2/</url>
+                </repository>
+                <repository>
+                        <id>jitpack.io</id>
+                        <url>https://jitpack.io</url>
                 </repository>
         </repositories>
         <!-- Dependency management for AWS SDK was unused and caused network resolution issues


### PR DESCRIPTION
## Summary
- use JitPack-hosted AlphaVantage4J v1.5.0
- add JitPack repository to Maven config

## Testing
- `mvn -U install -rf :timeseries-sources` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689d098fbd4c8327a4be2eb249d50111