### PR TITLE
Resolve instrument currency automatically

### DIFF
--- a/timeseries-lambda/src/main/java/com/leonarduk/aws/QueryRunner.java
+++ b/timeseries-lambda/src/main/java/com/leonarduk/aws/QueryRunner.java
@@ -87,12 +87,15 @@ public class QueryRunner {
 
         String region = StringUtils.defaultIfEmpty(inputParams.get("region"), "L");
         String type = StringUtils.defaultIfEmpty(inputParams.get("type"), "UNKNOWN");
-        String currency = StringUtils.defaultIfEmpty(inputParams.get("currency"), "GBP");
+        String currency = inputParams.get("currency");
 
         if (ticker.contains(".")) {
             String[] parts = ticker.split("\\.");
             ticker = parts[0];
             region = parts[1];
+            if ("N".equalsIgnoreCase(region)) {
+                region = "NY";
+            }
         }
 
         if (ticker.contains("/")) {
@@ -106,6 +109,10 @@ public class QueryRunner {
             if (parts.length > 3) {
                 currency = parts[3];
             }
+        }
+
+        if (StringUtils.isBlank(currency)) {
+            currency = Instrument.resolveCurrency(inputParams.get(TICKER));
         }
         final Instrument instrument = Instrument.fromString(ticker, region, type, currency);
 

--- a/timeseries-lambda/src/test/java/com/leonarduk/aws/QueryRunnerTest.java
+++ b/timeseries-lambda/src/test/java/com/leonarduk/aws/QueryRunnerTest.java
@@ -69,4 +69,21 @@ class QueryRunnerTest {
         Assertions.assertEquals("USD", feed.lastInstrument.getCurrency());
 
     }
+
+    @Test
+    void currencyAutomaticallyResolved() throws Exception {
+        QueryRunner runner = new QueryRunner();
+        RecordingStockFeed feed = new RecordingStockFeed();
+        Field field = QueryRunner.class.getDeclaredField("stockFeed");
+        field.setAccessible(true);
+        field.set(runner, feed);
+
+        Map<String, String> params = Map.of(
+                QueryRunner.TICKER, "BBAI.N"
+        );
+
+        runner.getResults(params);
+
+        Assertions.assertEquals("USD", feed.lastInstrument.getCurrency());
+    }
 }

--- a/timeseries-stockfeed/src/test/java/com/leonarduk/finance/stockfeed/InstrumentTest.java
+++ b/timeseries-stockfeed/src/test/java/com/leonarduk/finance/stockfeed/InstrumentTest.java
@@ -83,4 +83,12 @@ public class InstrumentTest {
         mapAfter.put("XDND", removed);
     }
 
+    @Test
+    public void testPopulateCurrencyResolvesFromFeed() {
+        Instrument unresolved = Instrument.fromString("BBAI.N");
+        Assert.assertEquals("UNKNOWN", unresolved.getCurrency());
+        Instrument resolved = Instrument.populateCurrency(unresolved);
+        Assert.assertEquals("USD", resolved.getCurrency());
+    }
+
 }


### PR DESCRIPTION
## Summary
- Resolve instrument currency by looking up InstrumentLoader and falling back to live Yahoo Finance feed
- Default unknown currency handling in Instrument and helper to populate missing values
- Adjust QueryRunner to use resolved currency and respect region code
- Add tests for automatic USD resolution for BBAI.N

## Testing
- `mvn -q -pl timeseries-stockfeed,timeseries-lambda -am test` *(fails: Network is unreachable)*


------
https://chatgpt.com/codex/tasks/task_e_689d0ed3cdd88327b6d75ddbc549e280