### PR TITLE
Fix patch path in timeseries API tests

### DIFF
--- a/timeseries-python/tests/test_timeseries_api.py
+++ b/timeseries-python/tests/test_timeseries_api.py
@@ -12,7 +12,7 @@ from analysis.portfolio.timeseries_api import get_time_series  # noqa: E402
 
 
 class TestGetTimeSeries(unittest.TestCase):
-    @patch("timeseries_api.requests.post")
+    @patch("analysis.portfolio.timeseries_api.requests.post")
     def test_fetches_data_for_single_ticker(self, mock_post):
         mock_response = MagicMock()
         mock_response.json.return_value = {
@@ -26,7 +26,7 @@ class TestGetTimeSeries(unittest.TestCase):
         self.assertIn("AAPL", result.columns)
         self.assertEqual(result.loc["2023-01-01", "AAPL"], 150)
 
-    @patch("timeseries_api.requests.post")
+    @patch("analysis.portfolio.timeseries_api.requests.post")
     def test_fetches_data_for_multiple_tickers(self, mock_post):
         mock_response = MagicMock()
         mock_response.json.return_value = {
@@ -42,7 +42,7 @@ class TestGetTimeSeries(unittest.TestCase):
         self.assertEqual(result.loc["2023-01-01", "AAPL"], 150)
         self.assertEqual(result.loc["2023-01-01", "MSFT"], 250)
 
-    @patch("timeseries_api.requests.post")
+    @patch("analysis.portfolio.timeseries_api.requests.post")
     def test_returns_empty_dataframe_when_no_data(self, mock_post):
         mock_response = MagicMock()
         mock_response.json.return_value = {}
@@ -52,7 +52,7 @@ class TestGetTimeSeries(unittest.TestCase):
 
         self.assertTrue(result.empty)
 
-    @patch("timeseries_api.requests.post")
+    @patch("analysis.portfolio.timeseries_api.requests.post")
     def test_skips_tickers_with_no_data(self, mock_post):
         mock_response = MagicMock()
         mock_response.json.return_value = {
@@ -65,7 +65,7 @@ class TestGetTimeSeries(unittest.TestCase):
         self.assertIn("AAPL", result.columns)
         self.assertNotIn("INVALID", result.columns)
 
-    @patch("timeseries_api.requests.post")
+    @patch("analysis.portfolio.timeseries_api.requests.post")
     def test_handles_invalid_json_response(self, mock_post):
         mock_response = MagicMock()
         mock_response.json.side_effect = ValueError("Invalid JSON")


### PR DESCRIPTION
## Summary
- patch requests.post using fully qualified analysis.portfolio.timeseries_api path in timeseries tests

## Testing
- `pytest tests/test_timeseries_api.py -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689d0ec321848327aab396bc1bbce445