### PR TITLE
Add parent POM for alphavantage4j module

### DIFF
--- a/alphavantage4j/pom.xml
+++ b/alphavantage4j/pom.xml
@@ -1,6 +1,12 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>com.leonarduk</groupId>
+        <artifactId>pension-risk-management-system</artifactId>
+        <version>0.1.4</version>
+        <relativePath>..</relativePath>
+    </parent>
     <groupId>org.patriques</groupId>
     <artifactId>alphavantage4j</artifactId>
     <version>1.5.0</version>


### PR DESCRIPTION
## Summary
- inherit plugin and repository management by referencing `pension-risk-management-system` parent in `alphavantage4j` module

## Testing
- `mvn clean install` *(fails: Could not transfer artifact org.apache.maven.plugins:maven-clean-plugin:pom:3.2.0 from/to central (https://repo.maven.apache.org/maven2): Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689d91d95e988327ae1cef9d7ce4c3b6