### PR TITLE
Fix module references in module-info

### DIFF
--- a/alphavantage4j/src/main/java/module-info.java
+++ b/alphavantage4j/src/main/java/module-info.java
@@ -1,6 +1,6 @@
 module org.patriques.alphavantage4j {
-    requires com.google.gson;
-    requires javax.annotation.api;
+    requires gson;
+    requires java.annotation;
     requires jsr305;
     exports org.patriques;
     exports org.patriques.input;


### PR DESCRIPTION
## Summary
- Use `gson` module instead of `com.google.gson`
- Use `java.annotation` instead of `javax.annotation.api`

## Testing
- `mvn clean install` *(fails: Could not resolve dependencies, network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689e3656486c8327b1e322f958924308