### PR TITLE
Use JDK 21 release in Maven compiler plugin

### DIFF
--- a/alphavantage4j/pom.xml
+++ b/alphavantage4j/pom.xml
@@ -36,4 +36,17 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>${maven.compiler.plugin.version}</version>
+                <configuration>
+                    <release>21</release>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -22,8 +22,7 @@
         <junit5.version>5.13.0-M3</junit5.version>
         <log4jdbc.log4j2.version>1.16</log4jdbc.log4j2.version>
         <maven.compiler.plugin.version>3.12.1</maven.compiler.plugin.version>
-        <maven.compiler.source>21</maven.compiler.source>
-        <maven.compiler.target>21</maven.compiler.target>
+        <maven.compiler.release>21</maven.compiler.release>
         <maven.shade.plugin.version>3.2.1</maven.shade.plugin.version>
         <org.slf4j.version>2.0.17</org.slf4j.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -41,8 +40,7 @@
                     <artifactId>maven-compiler-plugin</artifactId>
                     <version>${maven.compiler.plugin.version}</version>
                     <configuration>
-                        <source>${maven.compiler.source}</source>
-                        <target>${maven.compiler.target}</target>
+                        <release>${maven.compiler.release}</release>
                         <annotationProcessorPaths>
                             <path>
                                 <groupId>com.google.auto.service</groupId>

--- a/timeseries-lambda/pom.xml
+++ b/timeseries-lambda/pom.xml
@@ -83,8 +83,7 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>${maven.compiler.plugin.version}</version>
                 <configuration>
-                    <source>${maven.compiler.source}</source>
-                    <target>${maven.compiler.target}</target>
+                    <release>${maven.compiler.release}</release>
                     <annotationProcessorPaths>
                         <path>
                             <groupId>org.projectlombok</groupId>

--- a/timeseries-spring-boot-server/pom.xml
+++ b/timeseries-spring-boot-server/pom.xml
@@ -23,9 +23,8 @@
 		<java.version>21</java.version>
 		<log4jdbc.log4j2.version>1.16</log4jdbc.log4j2.version>
                 <rest.assured.version>5.5.0</rest.assured.version>
-		<maven.compiler.source>21</maven.compiler.source>
-		<maven.compiler.target>21</maven.compiler.target>
-		<jacoco.version>0.8.13</jacoco.version>
+                <maven.compiler.release>21</maven.compiler.release>
+                <jacoco.version>0.8.13</jacoco.version>
 		<jahoo.finance.version>3.15.0</jahoo.finance.version>
 		<org.ta4j.version>0.18</org.ta4j.version>
 	</properties>
@@ -114,8 +113,7 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.12.1</version>
                 <configuration>
-                    <source>${maven.compiler.source}</source>
-                    <target>${maven.compiler.target}</target>
+                    <release>${maven.compiler.release}</release>
                     <fork>true</fork>
                 </configuration>
             </plugin>


### PR DESCRIPTION
## Summary
- configure Maven compiler plugin to use Java release 21
- align module compiler settings with release flag

## Testing
- `mvn -q -Djava.net.preferIPv4Stack=true clean install` *(fails: org.springframework.boot:spring-boot-starter-parent:pom:3.5.3: Could not transfer artifact ... Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689e3657e9988327913d9688486e70ca