### PR TITLE
Use system temp dir and clean up after S3 upload

### DIFF
--- a/timeseries-lambda/src/main/java/com/leonarduk/aws/S3DataStore.java
+++ b/timeseries-lambda/src/main/java/com/leonarduk/aws/S3DataStore.java
@@ -16,6 +16,8 @@ import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.List;
 
 /**
@@ -54,6 +56,8 @@ public class S3DataStore extends AbstractCsvStockFeed implements DataStore {
                 getS3Filepath(stock.getInstrument()),
                 new File(filepath)
         );
+
+        Files.deleteIfExists(Paths.get(filepath));
     }
 
     @Override
@@ -80,8 +84,9 @@ public class S3DataStore extends AbstractCsvStockFeed implements DataStore {
 
     @Override
     protected String getQueryName(final Instrument instrument) {
-        return "/tmp/" + instrument.getExchange().name() + "_" + instrument.code()
-                + ".csv";
+        return Paths.get(System.getProperty("java.io.tmpdir"),
+                instrument.getExchange().name() + "_" + instrument.code() + ".csv")
+                .toString();
     }
 
     private String getS3Filepath(final Instrument instrument) {


### PR DESCRIPTION
## Summary
- Create temporary CSV files in the OS temp directory using `Paths.get` instead of a hardcoded `/tmp` path.
- Remove the local CSV file after uploading it to S3 to avoid clutter.

## Testing
- `mvn -q test` *(failed: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689e57f4fc50832795aa547a4fb85ff8