### PR TITLE
Use try-with-resources for API readers

### DIFF
--- a/alphavantage4j/src/main/java/org/patriques/AlphaVantageConnector.java
+++ b/alphavantage4j/src/main/java/org/patriques/AlphaVantageConnector.java
@@ -40,15 +40,16 @@ public class AlphaVantageConnector implements ApiConnector {
       connection.setConnectTimeout(timeOut);
       connection.setReadTimeout(timeOut);
 
-      InputStreamReader inputStream = new InputStreamReader(connection.getInputStream(), "UTF-8");
-      BufferedReader bufferedReader = new BufferedReader(inputStream);
       StringBuilder responseBuilder = new StringBuilder();
 
-      String line;
-      while ((line = bufferedReader.readLine()) != null) {
-        responseBuilder.append(line);
+      try (InputStreamReader inputStream =
+              new InputStreamReader(connection.getInputStream(), "UTF-8");
+          BufferedReader bufferedReader = new BufferedReader(inputStream)) {
+        String line;
+        while ((line = bufferedReader.readLine()) != null) {
+          responseBuilder.append(line);
+        }
       }
-      bufferedReader.close();
       return responseBuilder.toString();
     } catch (IOException e) {
       throw new AlphaVantageException("failure sending request", e);


### PR DESCRIPTION
## Summary
- wrap API input streams in try-with-resources to ensure proper closure

## Testing
- `mvn -q -f alphavantage4j/pom.xml test` *(fails: Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin:pom:3.3.1 from/to central: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689e57ec22988327ba02f8075d066af4