### PR TITLE
Handle duplicate dates in toMap operations

### DIFF
--- a/timeseries-spring-boot-server/src/main/java/com/leonarduk/finance/springboot/SeriesEndpoint.java
+++ b/timeseries-spring-boot-server/src/main/java/com/leonarduk/finance/springboot/SeriesEndpoint.java
@@ -66,8 +66,10 @@ public class SeriesEndpoint {
 
     private Map<LocalDate, Double> toSeries(List<Bar> history) {
         return history.stream().collect(
-                Collectors.toMap(bar -> bar.getEndTime().toLocalDate(),
-                        bar -> bar.getClosePrice().doubleValue()));
+                Collectors.toMap(
+                        bar -> bar.getEndTime().toLocalDate(),
+                        bar -> bar.getClosePrice().doubleValue(),
+                        (existing, replacement) -> existing));
     }
 
     private Map<LocalDate, Double> alignSeries(Map<LocalDate, Double> source, Map<LocalDate, Double> target) {

--- a/timeseries-spring-boot-server/src/test/java/com/leonarduk/finance/springboot/SeriesEndpointTest.java
+++ b/timeseries-spring-boot-server/src/test/java/com/leonarduk/finance/springboot/SeriesEndpointTest.java
@@ -61,4 +61,37 @@ class SeriesEndpointTest {
                 .andExpect(jsonPath("$.mapped['2023-01-03']").value(55.0))
                 .andExpect(jsonPath("$.mapped['2023-01-04']").value(60.0));
     }
+
+    @Test
+    void mapSeriesHandlesDuplicateDates() throws Exception {
+        List<Bar> srcQuotes = Arrays.asList(
+                new ExtendedHistoricalQuote(Instrument.CASH, LocalDate.parse("2023-01-01"), 100, 100, 100, 100, 100, 0, ""),
+                new ExtendedHistoricalQuote(Instrument.CASH, LocalDate.parse("2023-01-02"), 110, 110, 110, 110, 110, 0, ""),
+                new ExtendedHistoricalQuote(Instrument.CASH, LocalDate.parse("2023-01-02"), 115, 115, 115, 115, 115, 0, ""),
+                new ExtendedHistoricalQuote(Instrument.CASH, LocalDate.parse("2023-01-04"), 120, 120, 120, 120, 120, 0, "")
+        );
+        List<Bar> tgtQuotes = Arrays.asList(
+                new ExtendedHistoricalQuote(Instrument.UNKNOWN, LocalDate.parse("2023-01-01"), 50, 50, 50, 50, 50, 0, ""),
+                new ExtendedHistoricalQuote(Instrument.UNKNOWN, LocalDate.parse("2023-01-02"), 55, 55, 55, 55, 55, 0, ""),
+                new ExtendedHistoricalQuote(Instrument.UNKNOWN, LocalDate.parse("2023-01-02"), 57, 57, 57, 57, 57, 0, ""),
+                new ExtendedHistoricalQuote(Instrument.UNKNOWN, LocalDate.parse("2023-01-03"), 53, 53, 53, 53, 53, 0, ""),
+                new ExtendedHistoricalQuote(Instrument.UNKNOWN, LocalDate.parse("2023-01-04"), 58, 58, 58, 58, 58, 0, "")
+        );
+        StockV1 srcStock = AbstractStockFeed.createStock(Instrument.CASH, srcQuotes);
+        StockV1 tgtStock = AbstractStockFeed.createStock(Instrument.UNKNOWN, tgtQuotes);
+
+        Mockito.when(stockFeed.get(eq(Instrument.CASH), anyInt(), anyBoolean(), anyBoolean(), anyBoolean()))
+                .thenReturn(Optional.of(srcStock));
+        Mockito.when(stockFeed.get(eq(Instrument.UNKNOWN), anyInt(), anyBoolean(), anyBoolean(), anyBoolean()))
+                .thenReturn(Optional.of(tgtStock));
+
+        mockMvc.perform(post("/series/map")
+                        .param("source", "CASH")
+                        .param("target", "UNKNOWN"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.mapped['2023-01-01']").value(50.0))
+                .andExpect(jsonPath("$.mapped['2023-01-02']").value(55.0))
+                .andExpect(jsonPath("$.mapped['2023-01-03']").value(55.0))
+                .andExpect(jsonPath("$.mapped['2023-01-04']").value(60.0));
+    }
 }

--- a/timeseries-stockfeed/src/main/java/com/leonarduk/finance/stockfeed/AbstractStockFeed.java
+++ b/timeseries-stockfeed/src/main/java/com/leonarduk/finance/stockfeed/AbstractStockFeed.java
@@ -68,8 +68,13 @@ public abstract class AbstractStockFeed implements StockFeed {
     }
 
     public void mergeSeries(final StockV1 stock, final List<Bar> original, final List<Bar> newSeries) {
-        final Map<LocalDate, Bar> dates = original.stream()
-                .collect(Collectors.toMap(quote -> quote.getEndTime().toLocalDate(), Function.identity()));
+        final Map<LocalDate, Bar> dates =
+                original.stream()
+                        .collect(
+                                Collectors.toMap(
+                                        quote -> quote.getEndTime().toLocalDate(),
+                                        Function.identity(),
+                                        (existing, replacement) -> existing));
         newSeries.stream().forEach(historicalQuote -> {
             final LocalDate date = historicalQuote.getEndTime().toLocalDate();
             if ((date != null) && !dates.containsKey(date)

--- a/timeseries-stockfeed/src/test/java/com/leonarduk/finance/stockfeed/AbstractStockFeedMergeSeriesTest.java
+++ b/timeseries-stockfeed/src/test/java/com/leonarduk/finance/stockfeed/AbstractStockFeedMergeSeriesTest.java
@@ -1,0 +1,99 @@
+package com.leonarduk.finance.stockfeed;
+
+import com.leonarduk.finance.stockfeed.feed.ExtendedHistoricalQuote;
+import com.leonarduk.finance.stockfeed.feed.yahoofinance.StockV1;
+import org.junit.jupiter.api.Test;
+import org.ta4j.core.Bar;
+
+import java.time.LocalDate;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class AbstractStockFeedMergeSeriesTest {
+
+    @Test
+    void mergeSeriesHandlesDuplicateDates() {
+        AbstractStockFeed feed = new AbstractStockFeed() {
+            @Override
+            public Optional<StockV1> get(
+                    Instrument instrument, int years, boolean addLatestQuoteToTheSeries) {
+                return Optional.empty();
+            }
+
+            @Override
+            public Optional<StockV1> get(
+                    Instrument instrument,
+                    LocalDate fromDate,
+                    LocalDate toDate,
+                    boolean addLatestQuoteToTheSeries) {
+                return Optional.empty();
+            }
+
+            @Override
+            public Source getSource() {
+                return Source.MANUAL;
+            }
+
+            @Override
+            public boolean isAvailable() {
+                return true;
+            }
+        };
+
+        List<Bar> original =
+                Arrays.asList(
+                        new ExtendedHistoricalQuote(
+                                Instrument.CASH,
+                                LocalDate.parse("2023-01-01"),
+                                100,
+                                100,
+                                100,
+                                100,
+                                100,
+                                0,
+                                ""),
+                        new ExtendedHistoricalQuote(
+                                Instrument.CASH,
+                                LocalDate.parse("2023-01-01"),
+                                101,
+                                101,
+                                101,
+                                101,
+                                101,
+                                0,
+                                ""),
+                        new ExtendedHistoricalQuote(
+                                Instrument.CASH,
+                                LocalDate.parse("2023-01-02"),
+                                102,
+                                102,
+                                102,
+                                102,
+                                102,
+                                0,
+                                ""));
+        List<Bar> newSeries =
+                Arrays.asList(
+                        new ExtendedHistoricalQuote(
+                                Instrument.CASH,
+                                LocalDate.parse("2023-01-03"),
+                                103,
+                                103,
+                                103,
+                                103,
+                                103,
+                                0,
+                                ""));
+
+        StockV1 stock = AbstractStockFeed.createStock(Instrument.CASH, original);
+        feed.mergeSeries(stock, original, newSeries);
+
+        List<Bar> history = stock.getHistory();
+        assertEquals(3, history.size());
+        assertEquals(100.0, history.get(0).getClosePrice().doubleValue());
+    }
+}
+


### PR DESCRIPTION
## Summary
- Guard toMap conversions against duplicate keys by providing merge functions
- Add unit tests to ensure duplicate dates are handled during series mapping and merging

## Testing
- `mvn -q -pl timeseries-stockfeed,timeseries-spring-boot-server -am test` *(fails: Non-resolvable parent POM ... Network is unreachable)*
- `pre-commit run --files timeseries-spring-boot-server/src/main/java/com/leonarduk/finance/springboot/SeriesEndpoint.java timeseries-stockfeed/src/main/java/com/leonarduk/finance/stockfeed/AbstractStockFeed.java timeseries-spring-boot-server/src/test/java/com/leonarduk/finance/springboot/SeriesEndpointTest.java timeseries-stockfeed/src/test/java/com/leonarduk/finance/stockfeed/AbstractStockFeedMergeSeriesTest.java`

------
https://chatgpt.com/codex/tasks/task_e_689e57f1729483279ddacc5bf20f9253