### PR TITLE
Add serialVersionUID to AlphaVantageException

### DIFF
--- a/alphavantage4j/src/main/java/org/patriques/output/AlphaVantageException.java
+++ b/alphavantage4j/src/main/java/org/patriques/output/AlphaVantageException.java
@@ -1,6 +1,12 @@
 package org.patriques.output;
 
+/**
+ * Exception thrown when an error occurs while parsing or retrieving data from the
+ * Alpha Vantage service.
+ */
 public class AlphaVantageException extends RuntimeException {
+  private static final long serialVersionUID = 1L;
+
   public AlphaVantageException(String message, Exception e) {
     super(message, e);
   }


### PR DESCRIPTION
## Summary
- document AlphaVantageException purpose
- add serialVersionUID field for serialization stability

## Testing
- `mvn -q -pl alphavantage4j test` *(fails: Non-resolvable parent POM; Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689e57f08c78832793d3660abbb1ac07