### PR TITLE
Return builder from append methods and encode parameters

### DIFF
--- a/alphavantage4j/src/main/java/org/patriques/input/ApiParameterBuilder.java
+++ b/alphavantage4j/src/main/java/org/patriques/input/ApiParameterBuilder.java
@@ -1,5 +1,7 @@
 package org.patriques.input;
 
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import javax.annotation.Nullable;
 
 /**
@@ -13,27 +15,33 @@ public class ApiParameterBuilder {
   }
 
   /**
-   * Append an api paramter to the builder.
+   * Append an api parameter to the builder.
    *
    * @param apiParameter the api parameter to append to the url.
-   * @return an instance of this builder.
+   * @return this builder for method chaining.
    */
-  public void append(@Nullable ApiParameter apiParameter) {
+  public ApiParameterBuilder append(@Nullable ApiParameter apiParameter) {
     if (apiParameter != null) {
       append(apiParameter.getKey(), apiParameter.getValue());
     }
+    return this;
   }
 
   /**
-   * Append raw strings parameters to the builder, key and value.
+   * Append raw string parameters to the builder.
+   * <p>
+   * Both {@code key} and {@code value} are URL encoded before being appended.
    *
-   * @param key in the api paramter key value pair.
+   * @param key in the api parameter key value pair.
    * @param value in the api parameter key value pair.
-   * @return an instance of this builder.
+   * @return this builder for method chaining.
    */
-  public void append(String key, String value) {
-    String parameter = "&" + key + "=" + value;
+  public ApiParameterBuilder append(String key, String value) {
+    String encodedKey = URLEncoder.encode(key, StandardCharsets.UTF_8);
+    String encodedValue = URLEncoder.encode(value, StandardCharsets.UTF_8);
+    String parameter = "&" + encodedKey + "=" + encodedValue;
     this.urlBuilder.append(parameter);
+    return this;
   }
 
   /**

--- a/alphavantage4j/src/test/java/org/patriques/ApiParameterBuilderTest.java
+++ b/alphavantage4j/src/test/java/org/patriques/ApiParameterBuilderTest.java
@@ -12,8 +12,7 @@ public class ApiParameterBuilderTest {
     @Test
     public void testAppendParametersAndBuildUrl() {
         ApiParameterBuilder builder = new ApiParameterBuilder();
-        builder.append(new Symbol("IBM"));
-        builder.append("datatype", "json");
+        builder.append(new Symbol("IBM")).append("datatype", "json");
         assertEquals("&symbol=IBM&datatype=json", builder.getUrl());
     }
 
@@ -22,5 +21,12 @@ public class ApiParameterBuilderTest {
         ApiParameterBuilder builder = new ApiParameterBuilder();
         builder.append((ApiParameter) null);
         assertEquals("", builder.getUrl());
+    }
+
+    @Test
+    public void testAppendEncodesParameters() {
+        ApiParameterBuilder builder = new ApiParameterBuilder();
+        builder.append("sp ce", "a+b");
+        assertEquals("&sp+ce=a%2Bb", builder.getUrl());
     }
 }


### PR DESCRIPTION
## Summary
- Return `ApiParameterBuilder` from both `append` methods to allow chaining
- URL encode parameter keys and values before appending
- Add test verifying parameter encoding

## Testing
- `pre-commit run --files alphavantage4j/src/main/java/org/patriques/input/ApiParameterBuilder.java alphavantage4j/src/test/java/org/patriques/ApiParameterBuilderTest.java`
- `mvn -q test` *(fails: Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin:pom:3.3.1 from/to central: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689e57ecdc8483278da7dfe8527672d5