### PR TITLE
Add TA4J dependency to stockfeed module

### DIFF
--- a/timeseries-stockfeed/pom.xml
+++ b/timeseries-stockfeed/pom.xml
@@ -18,5 +18,10 @@
             <artifactId>commons-text</artifactId>
             <version>1.11.0</version>
         </dependency>
+        <dependency>
+            <groupId>org.ta4j</groupId>
+            <artifactId>ta4j-core</artifactId>
+            <version>${org.ta4j.version}</version>
+        </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
## Summary
- include ta4j-core dependency in timeseries-stockfeed module

## Testing
- `pre-commit run --files timeseries-stockfeed/pom.xml` *(fails: command not found)*
- `mvn -q -pl timeseries-stockfeed test` *(fails: Non-resolvable POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689e602a31e4832780511845887b7e16