### PR TITLE
Refactor time series utilities to BarSeries API

### DIFF
--- a/timeseries-stockfeed/src/main/java/com/leonarduk/finance/stockfeed/datatransformation/interpolation/AbstractLineInterpolator.java
+++ b/timeseries-stockfeed/src/main/java/com/leonarduk/finance/stockfeed/datatransformation/interpolation/AbstractLineInterpolator.java
@@ -5,7 +5,7 @@ import com.leonarduk.finance.stockfeed.feed.ExtendedHistoricalQuoteTimeSeries;
 import com.leonarduk.finance.utils.DateUtils;
 import com.leonarduk.finance.utils.TimeseriesUtils;
 import org.ta4j.core.Bar;
-import org.ta4j.core.TimeSeries;
+import org.ta4j.core.BarSeries;
 
 import java.io.IOException;
 import java.time.LocalDate;
@@ -71,7 +71,7 @@ public abstract class AbstractLineInterpolator implements TimeSeriesInterpolator
     }
 
     @Override
-    public TimeSeries interpolate(final TimeSeries timeseries) {
+    public BarSeries interpolate(final BarSeries timeseries) {
         if (timeseries.getEndIndex() < 0) {
             return timeseries;
         }

--- a/timeseries-stockfeed/src/main/java/com/leonarduk/finance/stockfeed/datatransformation/interpolation/TimeSeriesInterpolator.java
+++ b/timeseries-stockfeed/src/main/java/com/leonarduk/finance/stockfeed/datatransformation/interpolation/TimeSeriesInterpolator.java
@@ -2,7 +2,7 @@ package com.leonarduk.finance.stockfeed.datatransformation.interpolation;
 
 import com.leonarduk.finance.stockfeed.datatransformation.DataTransformer;
 import org.ta4j.core.Bar;
-import org.ta4j.core.TimeSeries;
+import org.ta4j.core.BarSeries;
 
 import java.io.IOException;
 import java.util.List;
@@ -14,7 +14,7 @@ public interface TimeSeriesInterpolator extends DataTransformer {
         return interpolate(history);
     }
 
-    TimeSeries interpolate(TimeSeries series);
+    BarSeries interpolate(BarSeries series);
 
     List<Bar> interpolate(List<Bar> series) throws IOException;
 }

--- a/timeseries-stockfeed/src/main/java/com/leonarduk/finance/stockfeed/feed/ExtendedHistoricalQuoteTimeSeries.java
+++ b/timeseries-stockfeed/src/main/java/com/leonarduk/finance/stockfeed/feed/ExtendedHistoricalQuoteTimeSeries.java
@@ -2,17 +2,17 @@ package com.leonarduk.finance.stockfeed.feed;
 
 import com.google.common.collect.Lists;
 import org.ta4j.core.Bar;
-import org.ta4j.core.TimeSeries;
-import org.ta4j.core.num.DoubleNum;
+import org.ta4j.core.BarBuilder;
+import org.ta4j.core.BarSeries;
+import org.ta4j.core.bars.TimeBarBuilder;
+import org.ta4j.core.num.DoubleNumFactory;
 import org.ta4j.core.num.Num;
+import org.ta4j.core.num.NumFactory;
 
 import java.io.Serial;
-import java.time.Duration;
-import java.time.ZonedDateTime;
 import java.util.List;
-import java.util.function.Function;
 
-public class ExtendedHistoricalQuoteTimeSeries implements TimeSeries {
+public class ExtendedHistoricalQuoteTimeSeries implements BarSeries {
 
     /**
      *
@@ -20,6 +20,7 @@ public class ExtendedHistoricalQuoteTimeSeries implements TimeSeries {
     @Serial
     private static final long serialVersionUID = -4258117616509944879L;
     private final List<Bar> series;
+    private final NumFactory numFactory = DoubleNumFactory.getInstance();
 
     public ExtendedHistoricalQuoteTimeSeries() {
         this(Lists.newArrayList());
@@ -88,29 +89,6 @@ public class ExtendedHistoricalQuoteTimeSeries implements TimeSeries {
     }
 
     @Override
-    public void addBar(Duration timePeriod, ZonedDateTime endTime) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public void addBar(ZonedDateTime endTime, Num openPrice, Num highPrice, Num lowPrice, Num closePrice, Num volume,
-                       Num amount) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public void addBar(Duration timePeriod, ZonedDateTime endTime, Num openPrice, Num highPrice, Num lowPrice,
-                       Num closePrice, Num volume) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public void addBar(Duration timePeriod, ZonedDateTime endTime, Num openPrice, Num highPrice, Num lowPrice,
-                       Num closePrice, Num volume, Num amount) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
     public void addTrade(Num tradeVolume, Num tradePrice) {
         throw new UnsupportedOperationException();
     }
@@ -121,18 +99,18 @@ public class ExtendedHistoricalQuoteTimeSeries implements TimeSeries {
     }
 
     @Override
-    public TimeSeries getSubSeries(int startIndex, int endIndex) {
+    public BarSeries getSubSeries(int startIndex, int endIndex) {
         return new ExtendedHistoricalQuoteTimeSeries(series.subList(startIndex, endIndex));
     }
 
     @Override
-    public Num numOf(Number number) {
-        return DoubleNum.valueOf(number);
+    public NumFactory numFactory() {
+        return numFactory;
     }
 
     @Override
-    public Function<Number, Num> function() {
-        throw new UnsupportedOperationException();
+    public BarBuilder barBuilder() {
+        return new TimeBarBuilder(numFactory);
     }
 
 }

--- a/timeseries-stockfeed/src/main/java/com/leonarduk/finance/stockfeed/file/IndicatorsToCsv.java
+++ b/timeseries-stockfeed/src/main/java/com/leonarduk/finance/stockfeed/file/IndicatorsToCsv.java
@@ -25,19 +25,19 @@ package com.leonarduk.finance.stockfeed.file;
 
 import com.leonarduk.finance.utils.FileUtils;
 import com.leonarduk.finance.utils.StringUtils;
-import org.ta4j.core.TimeSeries;
+import org.ta4j.core.BarSeries;
 import org.ta4j.core.indicators.*;
 import org.ta4j.core.indicators.helpers.ClosePriceIndicator;
-import org.ta4j.core.indicators.helpers.PriceVariationIndicator;
 import org.ta4j.core.indicators.helpers.TypicalPriceIndicator;
 import org.ta4j.core.indicators.statistics.StandardDeviationIndicator;
+import org.ta4j.core.num.Num;
 
 /**
  * This class builds a CSV file containing values from indicators.
  */
 public class IndicatorsToCsv {
 
-    public static void exportIndicatorsToCsv(final TimeSeries series) {
+    public static void exportIndicatorsToCsv(final BarSeries series) {
         final String fileName = "target/" + series.getName() + "_indicators.csv";
         /**
          * Creating indicators
@@ -46,8 +46,6 @@ public class IndicatorsToCsv {
         final ClosePriceIndicator closePrice = new ClosePriceIndicator(series);
         // Typical price
         final TypicalPriceIndicator typicalPrice = new TypicalPriceIndicator(series);
-        // Price variation
-        final PriceVariationIndicator priceVariation = new PriceVariationIndicator(series);
         // Simple moving averages
         final SMAIndicator shortSma = new SMAIndicator(closePrice, 8);
         final SMAIndicator longSma = new SMAIndicator(closePrice, 20);
@@ -81,7 +79,9 @@ public class IndicatorsToCsv {
             sb.append(series.getBar(i).getEndTime().toLocalDate()); //
             StringUtils.addValue(sb, (closePrice.getValue(i)));
             StringUtils.addValue(sb, (typicalPrice.getValue(i)));
-            StringUtils.addValue(sb, (priceVariation.getValue(i)));
+            Num previous = series.getBar(Math.max(0, i - 1)).getClosePrice();
+            Num current = series.getBar(i).getClosePrice();
+            StringUtils.addValue(sb, current.dividedBy(previous));
             StringUtils.addValue(sb, (shortSma.getValue(i)));
             StringUtils.addValue(sb, (longSma.getValue(i)));
             StringUtils.addValue(sb, (shortEma.getValue(i)));

--- a/timeseries-stockfeed/src/main/java/com/leonarduk/finance/utils/TimeseriesUtils.java
+++ b/timeseries-stockfeed/src/main/java/com/leonarduk/finance/utils/TimeseriesUtils.java
@@ -11,9 +11,10 @@ import com.leonarduk.finance.stockfeed.feed.ExtendedHistoricalQuote;
 import com.leonarduk.finance.stockfeed.feed.yahoofinance.StockV1;
 import com.leonarduk.finance.stockfeed.file.FileBasedDataStore;
 import org.ta4j.core.Bar;
-import org.ta4j.core.BaseTimeSeries;
-import org.ta4j.core.TimeSeries;
+import org.ta4j.core.BarSeries;
+import org.ta4j.core.BaseBarSeriesBuilder;
 import org.ta4j.core.num.DoubleNum;
+import org.ta4j.core.num.DoubleNumFactory;
 
 import java.io.IOException;
 import java.math.BigDecimal;
@@ -66,11 +67,11 @@ public class TimeseriesUtils {
         return history.get(0);
     }
 
-    public static TimeSeries getTimeSeries(final StockV1 stock, final int i, boolean addLatestQuoteToTheSeries) throws IOException {
+    public static BarSeries getTimeSeries(final StockV1 stock, final int i, boolean addLatestQuoteToTheSeries) throws IOException {
         return TimeseriesUtils.getTimeSeries(stock, LocalDate.now().minusYears(i), LocalDate.now(), addLatestQuoteToTheSeries);
     }
 
-    public static TimeSeries getTimeSeries(final StockV1 stock, final LocalDate fromDate, final LocalDate toDate, boolean addLatestQuoteToTheSeries)
+    public static BarSeries getTimeSeries(final StockV1 stock, final LocalDate fromDate, final LocalDate toDate, boolean addLatestQuoteToTheSeries)
             throws IOException {
         List<Bar> history = stock.getHistory();
         if ((null == history) || history.isEmpty()) {
@@ -95,7 +96,8 @@ public class TimeseriesUtils {
                 return null;
             }
         }
-        return new LinearInterpolator().interpolate(new BaseTimeSeries(stock.getName(), ticks));
+        return new LinearInterpolator().interpolate(
+                new BaseBarSeriesBuilder().withName(stock.getName()).withNumFactory(DoubleNumFactory.getInstance()).withBars(ticks).build());
     }
 
     public static Bar createSyntheticQuote(final Bar currentQuote, final LocalDate currentDate,

--- a/timeseries-stockfeed/src/test/java/com/leonarduk/finance/stockfeed/interpolation/FlatLineInterpolatorTest.java
+++ b/timeseries-stockfeed/src/test/java/com/leonarduk/finance/stockfeed/interpolation/FlatLineInterpolatorTest.java
@@ -9,8 +9,9 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.ta4j.core.Bar;
-import org.ta4j.core.BaseTimeSeries;
-import org.ta4j.core.TimeSeries;
+import org.ta4j.core.BarSeries;
+import org.ta4j.core.BaseBarSeriesBuilder;
+import org.ta4j.core.num.DoubleNumFactory;
 
 import java.time.LocalDate;
 import java.util.Arrays;
@@ -19,7 +20,7 @@ import java.util.stream.Collectors;
 
 public class FlatLineInterpolatorTest {
     private TimeSeriesInterpolator interpolator;
-    private TimeSeries series;
+    private BarSeries series;
 
     @Before
     public void setUp() throws Exception {
@@ -33,13 +34,13 @@ public class FlatLineInterpolatorTest {
                         105.0, 1000.0, 0, ""));
 
         final List<Bar> ticks = quotes.stream().map(ExtendedHistoricalQuote::new).collect(Collectors.toList());
-        this.series = new BaseTimeSeries(ticks);
+        this.series = new BaseBarSeriesBuilder().withNumFactory(DoubleNumFactory.getInstance()).withBars(ticks).build();
     }
 
     @Test
     public void testInterpolateTimeSeries() {
 
-        final TimeSeries actual = this.interpolator.interpolate(this.series);
+        final BarSeries actual = this.interpolator.interpolate(this.series);
         Assert.assertEquals(10, actual.getBarCount());
         Assert.assertEquals(LocalDate.parse("2017-04-03"), actual.getBar(0).getEndTime().toLocalDate());
         Assert.assertEquals(LocalDate.parse("2017-04-04"), actual.getBar(1).getEndTime().toLocalDate());
@@ -78,7 +79,7 @@ public class FlatLineInterpolatorTest {
 
     @Test
     public void testInterpolationSkipsDuplicatedFinalEntry() {
-        TimeSeries actual = this.interpolator.interpolate(this.series);
+        BarSeries actual = this.interpolator.interpolate(this.series);
         LocalDate finalDate = LocalDate.parse("2017-04-14");
         int count = 0;
         for (int i = 0; i < actual.getBarCount(); i++) {

--- a/timeseries-stockfeed/src/test/java/com/leonarduk/finance/stockfeed/interpolation/HolidayInterpolationTest.java
+++ b/timeseries-stockfeed/src/test/java/com/leonarduk/finance/stockfeed/interpolation/HolidayInterpolationTest.java
@@ -8,8 +8,9 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.ta4j.core.Bar;
-import org.ta4j.core.BaseTimeSeries;
-import org.ta4j.core.TimeSeries;
+import org.ta4j.core.BarSeries;
+import org.ta4j.core.BaseBarSeriesBuilder;
+import org.ta4j.core.num.DoubleNumFactory;
 
 import java.time.LocalDate;
 import java.util.Arrays;
@@ -20,7 +21,7 @@ import java.util.stream.Collectors;
  * Tests that interpolation skips recognised UK bank holidays.
  */
 public class HolidayInterpolationTest {
-    private TimeSeries series;
+    private BarSeries series;
 
     @Before
     public void setUp() {
@@ -30,13 +31,13 @@ public class HolidayInterpolationTest {
                 new ExtendedHistoricalQuote(Instrument.UNKNOWN, LocalDate.parse("2022-12-28"), 110.0, 110.0, 110.0,
                         110.0, 1000.0, 0, ""));
         List<Bar> ticks = quotes.stream().map(ExtendedHistoricalQuote::new).collect(Collectors.toList());
-        this.series = new BaseTimeSeries(ticks);
+        this.series = new BaseBarSeriesBuilder().withNumFactory(DoubleNumFactory.getInstance()).withBars(ticks).build();
     }
 
     @Test
     public void testSkipsUKBankHolidaysFlatLine() {
         TimeSeriesInterpolator flat = new FlatLineInterpolator();
-        TimeSeries actual = flat.interpolate(this.series);
+        BarSeries actual = flat.interpolate(this.series);
         Assert.assertEquals(2, actual.getBarCount());
         Assert.assertEquals(LocalDate.parse("2022-12-23"), actual.getBar(0).getEndTime().toLocalDate());
         Assert.assertEquals(LocalDate.parse("2022-12-28"), actual.getBar(1).getEndTime().toLocalDate());
@@ -49,7 +50,7 @@ public class HolidayInterpolationTest {
     @Test
     public void testSkipsUKBankHolidaysLinear() {
         TimeSeriesInterpolator linear = new com.leonarduk.finance.stockfeed.datatransformation.interpolation.LinearInterpolator();
-        TimeSeries actual = linear.interpolate(this.series);
+        BarSeries actual = linear.interpolate(this.series);
         Assert.assertEquals(2, actual.getBarCount());
         Assert.assertEquals(LocalDate.parse("2022-12-23"), actual.getBar(0).getEndTime().toLocalDate());
         Assert.assertEquals(LocalDate.parse("2022-12-28"), actual.getBar(1).getEndTime().toLocalDate());

--- a/timeseries-stockfeed/src/test/java/com/leonarduk/finance/stockfeed/interpolation/LinearInterpolatorTest.java
+++ b/timeseries-stockfeed/src/test/java/com/leonarduk/finance/stockfeed/interpolation/LinearInterpolatorTest.java
@@ -10,9 +10,10 @@ import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.ta4j.core.Bar;
-import org.ta4j.core.BaseTimeSeries;
-import org.ta4j.core.TimeSeries;
+import org.ta4j.core.BarSeries;
+import org.ta4j.core.BaseBarSeriesBuilder;
 import org.ta4j.core.num.DoubleNum;
+import org.ta4j.core.num.DoubleNumFactory;
 
 import java.time.LocalDate;
 import java.util.ArrayList;
@@ -23,7 +24,7 @@ import com.leonarduk.finance.utils.TimeseriesUtils;
 
 public class LinearInterpolatorTest {
     private TimeSeriesInterpolator interpolator;
-    private TimeSeries series;
+    private BarSeries series;
 
     @Before
     public void setUp() throws Exception {
@@ -37,13 +38,13 @@ public class LinearInterpolatorTest {
                         110.0, 2000.0, 0, ""));
 
         final List<Bar> ticks = quotes.stream().map(ExtendedHistoricalQuote::new).collect(Collectors.toList());
-        this.series = new BaseTimeSeries(ticks);
+        this.series = new BaseBarSeriesBuilder().withNumFactory(DoubleNumFactory.getInstance()).withBars(ticks).build();
     }
 
     @Test
     @Ignore
     public void testInterpolateTimeseries() {
-        final TimeSeries actual = this.interpolator.interpolate(this.series);
+        final BarSeries actual = this.interpolator.interpolate(this.series);
         Assert.assertEquals(10, actual.getBarCount());
         Assert.assertEquals(LocalDate.parse("2017-04-03"), actual.getBar(0).getEndTime().toLocalDate());
         Assert.assertEquals(LocalDate.parse("2017-04-04"), actual.getBar(1).getEndTime().toLocalDate());
@@ -73,14 +74,14 @@ public class LinearInterpolatorTest {
         List<Bar> extended = new FlatLineInterpolator().extendToToDate(base,
                 LocalDate.parse("2017-04-14"));
 
-        TimeSeries ts = new LinearInterpolator().interpolate(new BaseTimeSeries(extended));
+        BarSeries ts = new LinearInterpolator().interpolate(new BaseBarSeriesBuilder().withNumFactory(DoubleNumFactory.getInstance()).withBars(extended).build());
         Assert.assertEquals(LocalDate.parse("2017-04-13"),
                 ts.getBar(ts.getBarCount() - 1).getEndTime().toLocalDate());
     }
 
     @Test
     public void testInterpolateSkipsDuplicatedFinalEntry() {
-        TimeSeries actual = this.interpolator.interpolate(this.series);
+        BarSeries actual = this.interpolator.interpolate(this.series);
         LocalDate finalDate = LocalDate.parse("2017-04-14");
         int count = 0;
         for (int i = 0; i < actual.getBarCount(); i++) {


### PR DESCRIPTION
## Summary
- migrate time series utilities and interpolators from `TimeSeries`/`BaseTimeSeries` to `BarSeries`/`BaseBarSeries`
- replace deprecated `PriceVariationIndicator` with direct price change calculation
- update tests to align with BarSeries API

## Testing
- `mvn -q -pl timeseries-stockfeed -am test` *(fails: Non-resolvable import POM due to network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689e601f9b5c8327a68c880f364fe6e6