### PR TITLE
Add explicit SMA/EMA ta4j helper imports

### DIFF
--- a/timeseries-stockfeed/src/main/java/com/leonarduk/finance/stockfeed/file/IndicatorsToCsv.java
+++ b/timeseries-stockfeed/src/main/java/com/leonarduk/finance/stockfeed/file/IndicatorsToCsv.java
@@ -28,6 +28,8 @@ import com.leonarduk.finance.utils.StringUtils;
 import org.ta4j.core.BarSeries;
 import org.ta4j.core.indicators.*;
 import org.ta4j.core.indicators.helpers.ClosePriceIndicator;
+import org.ta4j.core.indicators.helpers.EMAIndicator;
+import org.ta4j.core.indicators.helpers.SMAIndicator;
 import org.ta4j.core.indicators.helpers.TypicalPriceIndicator;
 import org.ta4j.core.indicators.statistics.StandardDeviationIndicator;
 import org.ta4j.core.num.Num;


### PR DESCRIPTION
## Summary
- add SMAIndicator and EMAIndicator helper imports so IndicatorsToCsv compiles with ta4j 0.18

## Testing
- `mvn -q -pl timeseries-stockfeed -am test` *(fails: Non-resolvable import POM: Could not transfer artifact ... Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689e68dd44c88327924f72b94e877e61