### PR TITLE
Replace getMinPrice/MaxPrice with new API

### DIFF
--- a/timeseries-stockfeed/src/main/java/com/leonarduk/finance/stockfeed/AbstractStockFeed.java
+++ b/timeseries-stockfeed/src/main/java/com/leonarduk/finance/stockfeed/AbstractStockFeed.java
@@ -19,7 +19,7 @@ public abstract class AbstractStockFeed implements StockFeed {
 
         if ((quotes != null) && !quotes.isEmpty()) {
             final Bar historicalQuote = quotes.get(quotes.size() - 1);
-            quoteBuilder.setDayHigh(historicalQuote.getMaxPrice()).setDayLow(historicalQuote.getMinPrice())
+            quoteBuilder.setDayHigh(historicalQuote.getHighPrice()).setDayLow(historicalQuote.getLowPrice())
                     .setOpen(historicalQuote.getOpenPrice()).setAvgVolume(historicalQuote.getVolume().longValue())
                     .setPrice(historicalQuote.getClosePrice());
             stock.setQuote(quoteBuilder.build());

--- a/timeseries-stockfeed/src/main/java/com/leonarduk/finance/stockfeed/datatransformation/correction/BadScalingCorrector.java
+++ b/timeseries-stockfeed/src/main/java/com/leonarduk/finance/stockfeed/datatransformation/correction/BadScalingCorrector.java
@@ -33,8 +33,8 @@ public class BadScalingCorrector implements TimeSeriesCleaner {
                         current.getEndTime().toLocalDate(),
 
                         scaleDown(current.getOpenPrice()),
-                        scaleDown(current.getMinPrice()),
-                        scaleDown(current.getMaxPrice()),
+                        scaleDown(current.getLowPrice()),
+                        scaleDown(current.getHighPrice()),
                         scaleDown(current.getClosePrice()),
 
                         current.getVolume(),
@@ -46,8 +46,8 @@ public class BadScalingCorrector implements TimeSeriesCleaner {
                         current.getEndTime().toLocalDate(),
 
                         scaleUp(current.getOpenPrice()),
-                        scaleUp(current.getMinPrice()),
-                        scaleUp(current.getMaxPrice()),
+                        scaleUp(current.getLowPrice()),
+                        scaleUp(current.getHighPrice()),
                         scaleUp(current.getClosePrice()),
 
                         current.getVolume(),

--- a/timeseries-stockfeed/src/main/java/com/leonarduk/finance/stockfeed/datatransformation/correction/ValueScalingTransformer.java
+++ b/timeseries-stockfeed/src/main/java/com/leonarduk/finance/stockfeed/datatransformation/correction/ValueScalingTransformer.java
@@ -29,8 +29,8 @@ public class ValueScalingTransformer implements TimeSeriesCleaner {
                                 current.getEndTime().toLocalDate(),
 
                                 current.getOpenPrice().multipliedBy(scalingFactor),
-                                current.getMinPrice().multipliedBy(scalingFactor),
-                                current.getMaxPrice().multipliedBy(scalingFactor),
+                                current.getLowPrice().multipliedBy(scalingFactor),
+                                current.getHighPrice().multipliedBy(scalingFactor),
                                 current.getClosePrice().multipliedBy(scalingFactor),
 
                                 current.getVolume(),

--- a/timeseries-stockfeed/src/main/java/com/leonarduk/finance/utils/TimeseriesUtils.java
+++ b/timeseries-stockfeed/src/main/java/com/leonarduk/finance/utils/TimeseriesUtils.java
@@ -149,8 +149,8 @@ public class TimeseriesUtils {
         for (final Bar historicalQuote : series) {
             sb.append(historicalQuote.getEndTime().toLocalDate().toString());
             StringUtils.addValue(sb, historicalQuote.getOpenPrice());
-            StringUtils.addValue(sb, historicalQuote.getMaxPrice());
-            StringUtils.addValue(sb, historicalQuote.getMinPrice());
+            StringUtils.addValue(sb, historicalQuote.getHighPrice());
+            StringUtils.addValue(sb, historicalQuote.getLowPrice());
             StringUtils.addValue(sb, historicalQuote.getClosePrice());
             StringUtils.addValue(sb, historicalQuote.getVolume());
             if (historicalQuote instanceof Commentable commentable) {


### PR DESCRIPTION
## Summary
- switch deprecated getMinPrice/getMaxPrice calls to getLowPrice/getHighPrice
- update value-scaling and quote builder utilities accordingly

## Testing
- `mvn -q -pl timeseries-stockfeed -am test` *(fails: could not resolve dependencies, network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689e68deae808327b8e792bface9497d