### PR TITLE
Use source and supply metadata in FxInstrument constructor

### DIFF
--- a/timeseries-stockfeed/src/main/java/com/leonarduk/finance/stockfeed/FxInstrument.java
+++ b/timeseries-stockfeed/src/main/java/com/leonarduk/finance/stockfeed/FxInstrument.java
@@ -5,9 +5,18 @@ import com.leonarduk.finance.stockfeed.StockFeed.Exchange;
 public final class FxInstrument extends Instrument {
 
     public FxInstrument(Source source, String currencyOne, String currencyTwo) {
-        super(currencyTwo + "/" + currencyTwo, AssetType.FX, AssetType.FX, Source.ALPHAVANTAGE,
-                currencyOne + currencyTwo, currencyOne + currencyTwo, Exchange.NA, currencyOne, currencyTwo,
-                currencyTwo);
+        super(currencyOne + "/" + currencyTwo,
+                AssetType.FX,
+                AssetType.FX,
+                source,
+                currencyOne + currencyTwo,
+                currencyOne + currencyTwo,
+                Exchange.NA,
+                currencyOne,
+                currencyTwo,
+                currencyTwo,
+                "",
+                true);
         this.currencyOne = currencyOne;
         this.currencyTwo = currencyTwo;
     }


### PR DESCRIPTION
## Summary
- include provided data source when constructing FX instruments
- pass Google code and active flag to base Instrument

## Testing
- `mvn -q -pl timeseries-stockfeed test` *(fails: Non-resolvable parent POM due to network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689e68d741c48327ba17f2c3684da1eb