### PR TITLE
Pin TA4J to 0.13 for legacy TimeSeries API

### DIFF
--- a/timeseries-sources/pom.xml
+++ b/timeseries-sources/pom.xml
@@ -21,7 +21,8 @@
                 <jakarta.persistence.version>3.2.0</jakarta.persistence.version>
                 <org.seleniumhq.selenium.version>4.13.0</org.seleniumhq.selenium.version>
                 <org.junit.jupiter.version>5.13.0-M3</org.junit.jupiter.version>
-                <org.ta4j.version>0.18</org.ta4j.version>
+                <!-- TA4J 0.14 replaced TimeSeries/BaseTimeSeries with BarSeries; 0.13 is the last version supporting our current API. Update once code migrates to BarSeries. -->
+                <org.ta4j.version>0.13</org.ta4j.version>
                 <org.jfree.version>3.4.4</org.jfree.version>
                 <org.apache.xmlgraphics.version>1.19</org.apache.xmlgraphics.version>
                 <alphavantage4j.version>1.5.0</alphavantage4j.version>


### PR DESCRIPTION
## Summary
- pin org.ta4j.version to 0.13 in timeseries-sources
- document that 0.13 is last TA4J with TimeSeries/BaseTimeSeries and note future migration to BarSeries

## Testing
- `mvn -f timeseries-stockfeed/pom.xml clean compile` *(fails: Non-resolvable import POM: aws-java-sdk-bom and jackson-bom; network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689e690959fc83278e0bfb01f2bc4c3e