### PR TITLE
Add deprecated price wrappers for Bar interface changes

### DIFF
--- a/timeseries-stockfeed/src/main/java/com/leonarduk/finance/stockfeed/feed/ExtendedHistoricalQuote.java
+++ b/timeseries-stockfeed/src/main/java/com/leonarduk/finance/stockfeed/feed/ExtendedHistoricalQuote.java
@@ -237,6 +237,16 @@ public class ExtendedHistoricalQuote extends HistoricalQuote
         return DoubleNum.valueOf(getHigh());
     }
 
+    @Deprecated
+    public Num getMinPrice() {
+        return getLowPrice();
+    }
+
+    @Deprecated
+    public Num getMaxPrice() {
+        return getHighPrice();
+    }
+
     @Override
     public Num getClosePrice() {
         return DoubleNum.valueOf(getClose());


### PR DESCRIPTION
## Summary
- add deprecated `getMinPrice` and `getMaxPrice` wrappers delegating to `getLowPrice` and `getHighPrice`
- keep constructor using `getLowPrice`/`getHighPrice`

## Testing
- `mvn -U clean compile` *(fails: Non-resolvable import POM due to network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689e6f4cf0148327ab8870216c32ec9f