### PR TITLE
Fix avg volume type in stock feed

### DIFF
--- a/timeseries-stockfeed/src/main/java/com/leonarduk/finance/stockfeed/AbstractStockFeed.java
+++ b/timeseries-stockfeed/src/main/java/com/leonarduk/finance/stockfeed/AbstractStockFeed.java
@@ -21,7 +21,7 @@ public abstract class AbstractStockFeed implements StockFeed {
         if ((quotes != null) && !quotes.isEmpty()) {
             final Bar historicalQuote = quotes.get(quotes.size() - 1);
             quoteBuilder.setDayHigh(historicalQuote.getHighPrice()).setDayLow(historicalQuote.getLowPrice())
-                    .setOpen(historicalQuote.getOpenPrice()).setAvgVolume(historicalQuote.getVolume())
+                    .setOpen(historicalQuote.getOpenPrice()).setAvgVolume(historicalQuote.getVolume().longValue())
                     .setPrice(historicalQuote.getClosePrice());
             stock.setQuote(quoteBuilder.build());
             stock.setHistory(quotes);


### PR DESCRIPTION
## Summary
- ensure average volume passed as primitive long to StockQuoteBuilder

## Testing
- `mvn -q test` *(fails: Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin:pom:3.3.1: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689f7ff63ed08327af02087072b4c4bb