### PR TITLE
Implement LocalDate to Calendar conversion and tests

### DIFF
--- a/timeseries-stockfeed/src/main/java/com/leonarduk/finance/utils/DateUtils.java
+++ b/timeseries-stockfeed/src/main/java/com/leonarduk/finance/utils/DateUtils.java
@@ -83,6 +83,11 @@ public class DateUtils {
         return LocalDateTime.ofInstant(calendar.toInstant(), calendar.getTimeZone().toZoneId()).toLocalDate();
     }
 
+    public static Calendar localDateToCalendar(LocalDate date) {
+        ZonedDateTime zonedDateTime = date.atStartOfDay(ZoneId.systemDefault());
+        return GregorianCalendar.from(zonedDateTime);
+    }
+
     public static Calendar dateToCalendar(final Date date) {
         final Calendar calendar = Calendar.getInstance();
         calendar.setTime(date);

--- a/timeseries-stockfeed/src/test/java/com/leonarduk/finance/utils/DateUtilsTest.java
+++ b/timeseries-stockfeed/src/test/java/com/leonarduk/finance/utils/DateUtilsTest.java
@@ -5,6 +5,8 @@ import org.junit.Ignore;
 import org.junit.Test;
 
 import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.Calendar;
 import java.util.Iterator;
 
 public class DateUtilsTest {
@@ -74,5 +76,23 @@ public class DateUtilsTest {
 
         Assert.assertEquals(LocalDate.parse("2017-06-01"), DateUtils.getPreviousDate(LocalDate.parse("2017-06-02")));
 
+    }
+
+    @Test
+    public void testLocalDateToCalendarConversion() {
+        LocalDate localDate = LocalDate.of(2023, 5, 20);
+        Calendar calendar = DateUtils.localDateToCalendar(localDate);
+        Assert.assertEquals(localDate.getYear(), calendar.get(Calendar.YEAR));
+        Assert.assertEquals(localDate.getMonthValue() - 1, calendar.get(Calendar.MONTH));
+        Assert.assertEquals(localDate.getDayOfMonth(), calendar.get(Calendar.DAY_OF_MONTH));
+        Assert.assertEquals(ZoneId.systemDefault(), calendar.getTimeZone().toZoneId());
+    }
+
+    @Test
+    public void testCalendarToLocalDateConversion() {
+        LocalDate localDate = LocalDate.of(2023, 5, 20);
+        Calendar calendar = DateUtils.localDateToCalendar(localDate);
+        LocalDate converted = DateUtils.calendarToLocalDate(calendar);
+        Assert.assertEquals(localDate, converted);
     }
 }


### PR DESCRIPTION
## Summary
- add `localDateToCalendar` using `GregorianCalendar` and system default zone
- test LocalDate <-> Calendar conversions

## Testing
- `mvn test` *(fails: Could not resolve maven-resources-plugin:3.3.1, Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689f7ffdfb348327a5c16aeaceabe1aa