### PR TITLE
Introduce Num-based volume accessor

### DIFF
--- a/timeseries-stockfeed/src/main/java/com/leonarduk/finance/stockfeed/AbstractStockFeed.java
+++ b/timeseries-stockfeed/src/main/java/com/leonarduk/finance/stockfeed/AbstractStockFeed.java
@@ -21,7 +21,7 @@ public abstract class AbstractStockFeed implements StockFeed {
         if ((quotes != null) && !quotes.isEmpty()) {
             final Bar historicalQuote = quotes.get(quotes.size() - 1);
             quoteBuilder.setDayHigh(historicalQuote.getHighPrice()).setDayLow(historicalQuote.getLowPrice())
-                    .setOpen(historicalQuote.getOpenPrice()).setAvgVolume(historicalQuote.getVolume())
+                    .setOpen(historicalQuote.getOpenPrice()).setAvgVolume(historicalQuote.getVolume().longValue())
                     .setPrice(historicalQuote.getClosePrice());
             stock.setQuote(quoteBuilder.build());
             stock.setHistory(quotes);

--- a/timeseries-stockfeed/src/main/java/com/leonarduk/finance/stockfeed/feed/ExtendedHistoricalQuote.java
+++ b/timeseries-stockfeed/src/main/java/com/leonarduk/finance/stockfeed/feed/ExtendedHistoricalQuote.java
@@ -100,13 +100,13 @@ public class ExtendedHistoricalQuote extends HistoricalQuote
     @Column
     private final Long volume;
 
-    @Override
-    public Long getVolume() {
+    public Long getVolumeLong() {
         return this.volume;
     }
 
-    public Num getVolumeAsNum() {
-        return DoubleNum.valueOf(getVolume() == null ? 0 : getVolume());
+    @Override
+    public Num getVolume() {
+        return DoubleNum.valueOf(getVolumeLong() == null ? 0 : getVolumeLong());
     }
 
     @Column(tag = true)
@@ -188,7 +188,7 @@ public class ExtendedHistoricalQuote extends HistoricalQuote
 
     public ExtendedHistoricalQuote(ExtendedHistoricalQuote original) {
         this(original.getSymbol(), original.getLocalDate(), original.getOpen(), original.getLow(), original.getHigh(),
-                original.getClose(), original.getAdjClose(), original.getVolume(), "");
+                original.getClose(), original.getAdjClose(), original.getVolumeLong(), "");
     }
 
 
@@ -259,7 +259,7 @@ public class ExtendedHistoricalQuote extends HistoricalQuote
 
     @Override
     public long getTrades() {
-        return getVolume() == null ? 0L : getVolume();
+        return getVolumeLong() == null ? 0L : getVolumeLong();
     }
 
     @Override


### PR DESCRIPTION
## Summary
- Rename historical quote volume getter to `getVolumeLong` and add Num-based `getVolume`
- Update constructors and trade counting to rely on `getVolumeLong`
- Adjust stock feed to convert Num volumes to longs when building quotes

## Testing
- `mvn -q test -DskipTests` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689f7ffbc9408327ab77fef2d89a017c