### PR TITLE
Use Num volume in ExtendedHistoricalQuote constructors

### DIFF
--- a/timeseries-stockfeed/src/main/java/com/leonarduk/finance/stockfeed/datatransformation/correction/BadScalingCorrector.java
+++ b/timeseries-stockfeed/src/main/java/com/leonarduk/finance/stockfeed/datatransformation/correction/BadScalingCorrector.java
@@ -9,7 +9,6 @@ import org.ta4j.core.num.Num;
 import java.time.ZoneId;
 import java.util.Iterator;
 import java.util.List;
-import java.time.ZoneId;
 
 public class BadScalingCorrector implements TimeSeriesCleaner {
 
@@ -39,7 +38,7 @@ public class BadScalingCorrector implements TimeSeriesCleaner {
                         scaleDown(current.getHighPrice()),
                         scaleDown(current.getClosePrice()),
 
-                        current.getVolume().longValue(),
+                        current.getVolume(),
                         comment + ": Scaled from " + current.getClosePrice() + " to " + scaleDown(current.getClosePrice()));
                 cleanedSeries.add(cleanedQuote);
             } else if (current.getClosePrice().multipliedBy(DoubleNum.valueOf(SCALE))
@@ -52,7 +51,7 @@ public class BadScalingCorrector implements TimeSeriesCleaner {
                         scaleUp(current.getHighPrice()),
                         scaleUp(current.getClosePrice()),
 
-                        current.getVolume().longValue(),
+                        current.getVolume(),
                         "Scaled from " + current.getClosePrice() + " to " + scaleUp(current.getClosePrice()));
                 cleanedSeries.add(cleanedQuote);
             } else {

--- a/timeseries-stockfeed/src/main/java/com/leonarduk/finance/stockfeed/datatransformation/correction/ValueScalingTransformer.java
+++ b/timeseries-stockfeed/src/main/java/com/leonarduk/finance/stockfeed/datatransformation/correction/ValueScalingTransformer.java
@@ -11,7 +11,6 @@ import java.time.ZoneId;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.stream.Collectors;
-import java.time.ZoneId;
 
 public class ValueScalingTransformer implements TimeSeriesCleaner {
 
@@ -35,7 +34,7 @@ public class ValueScalingTransformer implements TimeSeriesCleaner {
                                 current.getHighPrice().multipliedBy(scalingFactor),
                                 current.getClosePrice().multipliedBy(scalingFactor),
 
-                                current.getVolume().longValue(),
+                                current.getVolume(),
                                 instrument.isin() + " scaled from " + current.getClosePrice() + " to "
                                         + current.getClosePrice().multipliedBy(scalingFactor))
                         )


### PR DESCRIPTION
## Summary
- forward Num volume directly when building ExtendedHistoricalQuote in scaling correctors
- clean up duplicate imports

## Testing
- `pre-commit run --files timeseries-stockfeed/src/main/java/com/leonarduk/finance/stockfeed/datatransformation/correction/BadScalingCorrector.java timeseries-stockfeed/src/main/java/com/leonarduk/finance/stockfeed/datatransformation/correction/ValueScalingTransformer.java`
- `mvn -q -f timeseries-stockfeed/pom.xml test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 or one of its dependencies could not be resolved: The following artifacts could not be resolved: org.apache.maven.plugins:maven-resources-plugin:pom:3.3.1 (absent): Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin:pom:3.3.1 from/to central (https://repo.maven.apache.org/maven2): Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689f8001cb1483278bab64b8f268a6b5