### PR TITLE
fix spring boot server compile error

### DIFF
--- a/timeseries-spring-boot-server/pom.xml
+++ b/timeseries-spring-boot-server/pom.xml
@@ -114,7 +114,6 @@
                 <version>3.12.1</version>
                 <configuration>
                     <release>${maven.compiler.release}</release>
-                    <fork>true</fork>
                 </configuration>
             </plugin>
 			<plugin>


### PR DESCRIPTION
## Summary
- remove forked javac invocation from spring-boot server module to resolve compile failures

## Testing
- `mvn -Djava.net.preferIPv4Stack=true -pl timeseries-spring-boot-server -am test -e` *(fails: Non-resolvable parent POM due to network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689f91dbb7a88327b18671583c086d44