### PR TITLE
test: mock JavaMailSender in web tests

### DIFF
--- a/timeseries-spring-boot-server/src/main/java/com/leonarduk/finance/springboot/StockFeedEndpoint.java
+++ b/timeseries-spring-boot-server/src/main/java/com/leonarduk/finance/springboot/StockFeedEndpoint.java
@@ -14,6 +14,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.MessageSource;
 import org.springframework.context.i18n.LocaleContextHolder;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.http.MediaType;
 import org.ta4j.core.Bar;
 
 import com.google.common.collect.Lists;
@@ -59,7 +60,7 @@ public class StockFeedEndpoint {
      * @return HTML table with historical stock data
      * @throws IOException if data retrieval fails
      */
-    @GetMapping("/ticker/{ticker}")
+    @GetMapping(value = "/ticker/{ticker}", produces = MediaType.TEXT_HTML_VALUE)
     public String displayHistory(@PathVariable(name = "ticker") final String ticker,
                                  @RequestParam(name = "years", required = false) Integer years,
                                  @RequestParam(name = "fromDate", required = false) String fromDate,

--- a/timeseries-spring-boot-server/src/test/java/com/leonarduk/finance/springboot/CorsConfigTest.java
+++ b/timeseries-spring-boot-server/src/test/java/com/leonarduk/finance/springboot/CorsConfigTest.java
@@ -4,9 +4,11 @@ import com.leonarduk.finance.springboot.config.CorsConfig;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -22,6 +24,9 @@ class CorsConfigTest {
 
     @Autowired
     private MockMvc mockMvc;
+
+    @MockBean
+    private JavaMailSender mailSender;
 
     @RestController
     @RequestMapping("/stock")

--- a/timeseries-spring-boot-server/src/test/java/com/leonarduk/finance/springboot/RiskAnalysisEndpointTest.java
+++ b/timeseries-spring-boot-server/src/test/java/com/leonarduk/finance/springboot/RiskAnalysisEndpointTest.java
@@ -15,6 +15,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.mail.javamail.JavaMailSender;
 
 @WebMvcTest(RiskAnalysisEndpoint.class)
 class RiskAnalysisEndpointTest {
@@ -22,6 +23,8 @@ class RiskAnalysisEndpointTest {
     @Autowired private MockMvc mockMvc;
 
     @MockBean private RiskAnalysisService riskAnalysisService;
+
+    @MockBean private JavaMailSender mailSender;
 
     @Test
     void returnsMaxDrawdown() throws Exception {

--- a/timeseries-spring-boot-server/src/test/java/com/leonarduk/finance/springboot/SeriesEndpointTest.java
+++ b/timeseries-spring-boot-server/src/test/java/com/leonarduk/finance/springboot/SeriesEndpointTest.java
@@ -12,6 +12,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.ta4j.core.Bar;
+import org.springframework.mail.javamail.JavaMailSender;
 
 import java.time.LocalDate;
 import java.util.Arrays;
@@ -32,6 +33,9 @@ class SeriesEndpointTest {
     @MockBean
     private StockFeed stockFeed;
 
+    @MockBean
+    private JavaMailSender mailSender;
+
     @Test
     void mapSeriesAlignsSourceToTarget() throws Exception {
         List<Bar> srcQuotes = Arrays.asList(
@@ -48,9 +52,9 @@ class SeriesEndpointTest {
         StockV1 srcStock = AbstractStockFeed.createStock(Instrument.CASH, srcQuotes);
         StockV1 tgtStock = AbstractStockFeed.createStock(Instrument.UNKNOWN, tgtQuotes);
 
-        Mockito.when(stockFeed.get(eq(Instrument.CASH), anyInt(), anyBoolean(), anyBoolean(), anyBoolean()))
+        Mockito.when(stockFeed.get(argThat(i -> i != null && "CASH".equalsIgnoreCase(i.getCode())), anyInt(), anyBoolean(), anyBoolean(), anyBoolean()))
                 .thenReturn(Optional.of(srcStock));
-        Mockito.when(stockFeed.get(eq(Instrument.UNKNOWN), anyInt(), anyBoolean(), anyBoolean(), anyBoolean()))
+        Mockito.when(stockFeed.get(argThat(i -> i != null && "UNKNOWN".equalsIgnoreCase(i.getCode())), anyInt(), anyBoolean(), anyBoolean(), anyBoolean()))
                 .thenReturn(Optional.of(tgtStock));
 
         mockMvc.perform(post("/series/map")
@@ -80,9 +84,9 @@ class SeriesEndpointTest {
         StockV1 srcStock = AbstractStockFeed.createStock(Instrument.CASH, srcQuotes);
         StockV1 tgtStock = AbstractStockFeed.createStock(Instrument.UNKNOWN, tgtQuotes);
 
-        Mockito.when(stockFeed.get(eq(Instrument.CASH), anyInt(), anyBoolean(), anyBoolean(), anyBoolean()))
+        Mockito.when(stockFeed.get(argThat(i -> i != null && "CASH".equalsIgnoreCase(i.getCode())), anyInt(), anyBoolean(), anyBoolean(), anyBoolean()))
                 .thenReturn(Optional.of(srcStock));
-        Mockito.when(stockFeed.get(eq(Instrument.UNKNOWN), anyInt(), anyBoolean(), anyBoolean(), anyBoolean()))
+        Mockito.when(stockFeed.get(argThat(i -> i != null && "UNKNOWN".equalsIgnoreCase(i.getCode())), anyInt(), anyBoolean(), anyBoolean(), anyBoolean()))
                 .thenReturn(Optional.of(tgtStock));
 
         mockMvc.perform(post("/series/map")

--- a/timeseries-spring-boot-server/src/test/java/com/leonarduk/finance/springboot/StockFeedCorsTest.java
+++ b/timeseries-spring-boot-server/src/test/java/com/leonarduk/finance/springboot/StockFeedCorsTest.java
@@ -10,6 +10,7 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.mail.javamail.JavaMailSender;
 
 import java.util.Optional;
 
@@ -30,6 +31,9 @@ class StockFeedCorsTest {
 
     @MockBean
     private StockFeed stockFeed;
+
+    @MockBean
+    private JavaMailSender mailSender;
 
     @Test
     void corsHeadersPresentOnStockEndpoint() throws Exception {

--- a/timeseries-spring-boot-server/src/test/java/com/leonarduk/finance/springboot/StockFeedEndpointTest.java
+++ b/timeseries-spring-boot-server/src/test/java/com/leonarduk/finance/springboot/StockFeedEndpointTest.java
@@ -11,6 +11,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.http.MediaType;
+import org.springframework.mail.javamail.JavaMailSender;
 
 import java.time.LocalDate;
 import java.util.Collections;
@@ -31,11 +32,14 @@ class StockFeedEndpointTest {
     @MockBean
     private StockFeed stockFeed;
 
+    @MockBean
+    private JavaMailSender mailSender;
+
     @Test
     void displayHistoryReturnsHtmlTable() throws Exception {
         Instrument instrument = Instrument.CASH;
         StockV1 stock = AbstractStockFeed.createStock(instrument, Collections.emptyList());
-        Mockito.when(stockFeed.get(eq(instrument), eq(LocalDate.parse("2024-01-01")),
+        Mockito.when(stockFeed.get(argThat(i -> i.getCode().equals("CASH")), eq(LocalDate.parse("2024-01-01")),
                 eq(LocalDate.parse("2024-01-02")), anyBoolean(), anyBoolean(), anyBoolean()))
                 .thenReturn(Optional.of(stock));
 
@@ -54,7 +58,7 @@ class StockFeedEndpointTest {
     void displayHistoryAsJsonFiltersOutNonMatchingCategory() throws Exception {
         Instrument instrument = Instrument.CASH;
         StockV1 stock = AbstractStockFeed.createStock(instrument, Collections.emptyList());
-        Mockito.when(stockFeed.get(eq(instrument), eq(LocalDate.parse("2024-01-01")),
+        Mockito.when(stockFeed.get(argThat(i -> i.getCode().equals("CASH")), eq(LocalDate.parse("2024-01-01")),
                 eq(LocalDate.parse("2024-01-02")), anyBoolean(), anyBoolean(), anyBoolean()))
                 .thenReturn(Optional.of(stock));
 


### PR DESCRIPTION
## Summary
- mock JavaMailSender in MVC tests to allow Spring context load
- ensure StockFeed endpoint declares HTML content type
- adjust mocks for instrument code matching in Series and StockFeed tests

## Testing
- `mvn -pl timeseries-stockfeed,timeseries-spring-boot-server -am test`


------
https://chatgpt.com/codex/tasks/task_e_689f965196008327b556b41d50326d96