### PR TITLE
Switch timeseries-lambda to Log4j SLF4J implementation

### DIFF
--- a/timeseries-lambda/pom.xml
+++ b/timeseries-lambda/pom.xml
@@ -26,7 +26,7 @@
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-slf4j2</artifactId>
+            <artifactId>log4j-slf4j2-impl</artifactId>
             <version>2.23.1</version>
         </dependency>
 


### PR DESCRIPTION
## Summary
- use `log4j-slf4j2-impl` to provide the SLF4J API via Log4j
- keep `slf4j-api` since the module uses Lombok `@Slf4j`

## Testing
- `mvn -pl timeseries-lambda -am clean install` *(fails: Network is unreachable during dependency resolution)*

------
https://chatgpt.com/codex/tasks/task_e_689f9da4782083278be6615d4809a41f