### PR TITLE
chore: update Lombok processor version to 1.18.38

### DIFF
--- a/timeseries-lambda/pom.xml
+++ b/timeseries-lambda/pom.xml
@@ -88,7 +88,7 @@
                         <path>
                             <groupId>org.projectlombok</groupId>
                             <artifactId>lombok</artifactId>
-                            <version>1.18.36</version>
+                            <version>1.18.38</version>
                         </path>
                     </annotationProcessorPaths>
                 </configuration>


### PR DESCRIPTION
## Summary
- update Lombok annotation processor to version 1.18.38 in timeseries-lambda module

## Testing
- `mvn -pl timeseries-lambda -am clean install` *(fails: Network is unreachable for spring-boot-starter-parent)*

------
https://chatgpt.com/codex/tasks/task_e_689f9da5b2bc8327ac0e910ce909c2fe