### PR TITLE
Remove unused AWS SDK v2 and AssertJ dependencies

### DIFF
--- a/timeseries-lambda/src/main/java/com/leonarduk/aws/DependencyFactory.java
+++ b/timeseries-lambda/src/main/java/com/leonarduk/aws/DependencyFactory.java
@@ -1,8 +1,8 @@
 package com.leonarduk.aws;
 
+import com.amazonaws.regions.Regions;
 import com.leonarduk.finance.stockfeed.IntelligentStockFeed;
 import com.leonarduk.finance.stockfeed.StockFeed;
-import software.amazon.awssdk.regions.Region;
 
 public class DependencyFactory {
 
@@ -25,7 +25,7 @@ public class DependencyFactory {
                                     new S3DataStore(
                                             "timeseries-leonarduk",
                                             "timeseries",
-                                            Region.EU_WEST_1.toString()));
+                                            Regions.EU_WEST_1.getName()));
                 }
             }
         }

--- a/timeseries-lambda/src/main/java/com/leonarduk/aws/QueryRunner.java
+++ b/timeseries-lambda/src/main/java/com/leonarduk/aws/QueryRunner.java
@@ -8,9 +8,7 @@ import com.leonarduk.finance.utils.DataField;
 import com.leonarduk.finance.utils.HtmlTools;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
-import org.assertj.core.util.Lists;
 import org.ta4j.core.Bar;
-import software.amazon.awssdk.utils.ImmutableMap;
 
 import java.io.IOException;
 import java.time.LocalDate;
@@ -42,7 +40,7 @@ public class QueryRunner {
      * @throws IOException if an IO error occurs
      */
     public static void main(String[] args) throws IOException {
-        log.info(new QueryRunner().getResults(ImmutableMap.of(
+        log.info(new QueryRunner().getResults(Map.of(
                 TICKER, "PHGP.L",
                 YEARS, "1",
                 "interpolate", "true",
@@ -149,14 +147,14 @@ public class QueryRunner {
                                    final Instrument instrument)
             throws IOException {
         final StringBuilder sbBody = new StringBuilder();
-        final List<List<DataField>> records = Lists.newArrayList();
+        final List<List<DataField>> records = new ArrayList<>();
 
         final List<Bar> historyData;
 
         historyData = this.getHistoryData(instrument, fromLocalDate, toLocalDate, interpolate, cleanData, false);
 
         for (final Bar historicalQuote : historyData) {
-            final ArrayList<DataField> record = Lists.newArrayList();
+            final ArrayList<DataField> record = new ArrayList<>();
             records.add(record);
             record.add(new DataField("Date", historicalQuote.getEndTime().atZone(ZoneId.systemDefault()).toLocalDate().toString()));
             record.add(new DataField("Open", historicalQuote.getOpenPrice()));
@@ -182,7 +180,7 @@ public class QueryRunner {
         if (stock.isPresent()) {
             return stock.get().getHistory();
         }
-        return Lists.newArrayList();
+        return new ArrayList<>();
     }
 
 }

--- a/timeseries-lambda/src/main/java/com/leonarduk/aws/sqs/SqsHandler.java
+++ b/timeseries-lambda/src/main/java/com/leonarduk/aws/sqs/SqsHandler.java
@@ -8,7 +8,6 @@ import com.amazonaws.services.lambda.runtime.events.SQSEvent;
 import com.amazonaws.services.lambda.runtime.events.SQSEvent.SQSMessage;
 import com.leonarduk.aws.QueryRunner;
 import lombok.extern.slf4j.Slf4j;
-import software.amazon.awssdk.utils.ImmutableMap;
 
 import java.util.Map;
 
@@ -44,7 +43,7 @@ public class SqsHandler implements RequestHandler<SQSEvent, Void> {
     public Map<String, String> getParameterMap(String messageBody) {
         Gson gson = new Gson();
         QueryRequest request = gson.fromJson(messageBody, QueryRequest.class);
-        return ImmutableMap.of(
+        return Map.of(
                 QueryRunner.TICKER, request.getTicker(),
                 QueryRunner.YEARS, String.valueOf(request.getYears()),
                 QueryRunner.CLEAN_DATA, String.valueOf(request.isCleanData()),


### PR DESCRIPTION
## Summary
- Replace AWS `ImmutableMap` usage with Java `Map.of` in SQS handler and QueryRunner
- Swap AssertJ `Lists` helpers for standard Java collections
- Use AWS SDK v1 `Regions` enum for S3 data store configuration

## Testing
- `mvn -f timeseries-lambda/pom.xml test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 could not be resolved: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689fa1a41ee88327966c285b2e17eef3