### PR TITLE
feat: add currency fallback

### DIFF
--- a/timeseries-lambda/src/main/java/com/leonarduk/aws/QueryRunner.java
+++ b/timeseries-lambda/src/main/java/com/leonarduk/aws/QueryRunner.java
@@ -113,6 +113,11 @@ public class QueryRunner {
         if (StringUtils.isBlank(currency)) {
             currency = Instrument.resolveCurrency(inputParams.get(TICKER));
         }
+        final Map<String, String> regionCurrencyMap = Map.of("NY", "USD", "L", "GBP");
+        if ((StringUtils.isBlank(currency) || "UNKNOWN".equalsIgnoreCase(currency))
+                && regionCurrencyMap.containsKey(region.toUpperCase())) {
+            currency = regionCurrencyMap.get(region.toUpperCase());
+        }
         final Instrument instrument = Instrument.fromString(ticker, region, type, currency);
 
         LocalDate toLocalDate;


### PR DESCRIPTION
## Summary
- default currency to region-based mapping when missing or unknown

## Testing
- `pre-commit run --files timeseries-lambda/src/main/java/com/leonarduk/aws/QueryRunner.java`
- `mvn -q test` *(fails: Could not resolve maven-resources-plugin: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689fafbdfc748327bb2adcf227962e64