### PR TITLE
docs: add timeseries-stockfeed module section

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,3 +104,25 @@ docker run \
   <image>
 ```
 
+## timeseries-stockfeed
+
+The `timeseries-stockfeed` module fetches and prepares historical stock and FX data from providers such as AlphaVantage, Stooq, Yahoo Finance and the Financial Times. It handles caching, data cleansing and interpolation so other modules can work with consistent time series.
+
+### Prerequisites
+
+* Java 11 or later
+* Maven 3.6 or later
+* Optional: `ALPHAVANTAGE_API_KEYS` environment variable for AlphaVantage access (comma-separated list of keys)
+
+### Build and test
+
+Compile the module and run its tests with:
+
+```bash
+mvn -pl timeseries-stockfeed -am verify
+```
+
+### Additional documentation
+
+For a Python client that consumes this stockfeed, see the [timeseries-python integration](timeseries-python/integrations/stockfeed/README.md).
+


### PR DESCRIPTION
## Summary
- document the timeseries-stockfeed module and its purpose in the root README
- include prerequisites, Maven build instructions, and a link to the Python integration docs

## Testing
- `pre-commit run --files README.md`
- `mvn -q -f timeseries-stockfeed/pom.xml verify` *(fails: Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin:pom:3.3.1 from/to central: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689fba1038cc8327a5284ef3ca424852