### PR TITLE
Silence HtmlUnit CSS warnings

### DIFF
--- a/timeseries-spring-boot-server/src/main/resources/application.properties
+++ b/timeseries-spring-boot-server/src/main/resources/application.properties
@@ -1,5 +1,6 @@
 server.port = 8091
 logging.level.org.springframework=INFO
+logging.level.com.gargoylesoftware.htmlunit=ERROR
 portfolio.summary.cron=0 0 8,18 * * *
 portfolio.summary.recipient=test@example.com
 spring.mail.host=localhost

--- a/timeseries-stockfeed/src/main/java/com/leonarduk/finance/stockfeed/feed/ft/FTFeed.java
+++ b/timeseries-stockfeed/src/main/java/com/leonarduk/finance/stockfeed/feed/ft/FTFeed.java
@@ -4,6 +4,8 @@ import com.leonarduk.finance.stockfeed.AbstractStockFeed;
 import com.leonarduk.finance.stockfeed.Instrument;
 import com.leonarduk.finance.stockfeed.Source;
 import com.leonarduk.finance.stockfeed.feed.yahoofinance.StockV1;
+import com.gargoylesoftware.htmlunit.SilentCssErrorHandler;
+import com.gargoylesoftware.htmlunit.WebClient;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.htmlunit.HtmlUnitDriver;
 import org.slf4j.Logger;
@@ -26,7 +28,11 @@ public class FTFeed extends AbstractStockFeed {
     final WebDriver webDriver;
 
     public FTFeed() {
-        webDriver = new HtmlUnitDriver(false);
+        HtmlUnitDriver driver = new HtmlUnitDriver(false);
+        WebClient webClient = driver.getWebClient();
+        webClient.getOptions().setCssEnabled(false);
+        webClient.setCssErrorHandler(new SilentCssErrorHandler());
+        webDriver = driver;
     }
 
     @Override

--- a/timeseries-stockfeed/src/test/java/com/leonarduk/finance/stockfeed/feed/ft/FTTimeSeriesPageTest.java
+++ b/timeseries-stockfeed/src/test/java/com/leonarduk/finance/stockfeed/feed/ft/FTTimeSeriesPageTest.java
@@ -1,6 +1,8 @@
 package com.leonarduk.finance.stockfeed.feed.ft;
 
 import com.leonarduk.finance.stockfeed.Instrument;
+import com.gargoylesoftware.htmlunit.SilentCssErrorHandler;
+import com.gargoylesoftware.htmlunit.WebClient;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -21,7 +23,11 @@ public class FTTimeSeriesPageTest {
 
     @Before
     public void setUp() {
-        webDriver = new HtmlUnitDriver();
+        HtmlUnitDriver driver = new HtmlUnitDriver();
+        WebClient webClient = driver.getWebClient();
+        webClient.getOptions().setCssEnabled(false);
+        webClient.setCssErrorHandler(new SilentCssErrorHandler());
+        webDriver = driver;
     }
 
     @After


### PR DESCRIPTION
## Summary
- disable HtmlUnit CSS processing and error handler in FTFeed to prevent noisy logs
- configure Spring Boot logging to suppress HtmlUnit messages
- align test HtmlUnitDriver setup with production configuration

## Testing
- `mvn -q -pl timeseries-stockfeed,timeseries-spring-boot-server -am test` *(fails: Non-resolvable parent POM for com.leonarduk:timeseries-spring-boot-server)*
- `mvn -q -f timeseries-stockfeed/pom.xml test` *(fails: maven-resources-plugin:3.3.1 could not be resolved: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689fbb8a596483279d76bc95e77acf4f