### PR TITLE
Implement request limiter for Stooq feed and surface errors

### DIFF
--- a/timeseries-stockfeed/src/main/java/com/leonarduk/finance/stockfeed/IntelligentStockFeed.java
+++ b/timeseries-stockfeed/src/main/java/com/leonarduk/finance/stockfeed/IntelligentStockFeed.java
@@ -6,6 +6,7 @@ import com.leonarduk.finance.stockfeed.feed.ExtendedHistoricalQuote;
 import com.leonarduk.finance.stockfeed.feed.yahoofinance.ExtendedStockQuote;
 import com.leonarduk.finance.stockfeed.feed.yahoofinance.StockQuoteBuilder;
 import com.leonarduk.finance.stockfeed.feed.yahoofinance.StockV1;
+import com.leonarduk.finance.stockfeed.feed.stooq.DailyLimitExceededException;
 import com.leonarduk.finance.utils.DateUtils;
 import com.leonarduk.finance.utils.TimeseriesUtils;
 import org.slf4j.Logger;
@@ -81,7 +82,7 @@ public class IntelligentStockFeed extends AbstractStockFeed implements StockFeed
     }
 
     @Override
-    public Optional<StockV1> get(final Instrument instrument, final int years, boolean addLatestQuoteToTheSeries) {
+    public Optional<StockV1> get(final Instrument instrument, final int years, boolean addLatestQuoteToTheSeries) throws IOException {
         return this.get(instrument, LocalDate.now().minusYears(years), LocalDate.now(), false, false, addLatestQuoteToTheSeries);
     }
 
@@ -99,9 +100,11 @@ public class IntelligentStockFeed extends AbstractStockFeed implements StockFeed
 
     @Override
     public Optional<StockV1> get(final Instrument instrument, final LocalDate fromDateRaw, final LocalDate toDateRaw,
-                                 final boolean interpolate, boolean cleanData, boolean addLatestQuoteToTheSeries) {
+                                 final boolean interpolate, boolean cleanData, boolean addLatestQuoteToTheSeries) throws IOException {
         try {
             return getUsingCache(instrument, fromDateRaw, toDateRaw, interpolate, cleanData, addLatestQuoteToTheSeries);
+        } catch (final DailyLimitExceededException e) {
+            throw e;
         } catch (final Exception e) {
             System.err.println(Arrays.toString(e.getStackTrace()));
             IntelligentStockFeed.log.warn("Failed to get data {}", e.getMessage());
@@ -172,6 +175,8 @@ public class IntelligentStockFeed extends AbstractStockFeed implements StockFeed
                         webdata = this.getDataIfFeedAvailable(instrument, fromDate1,
                                 toDate1, webDataFeed, refresh, addLatestQuoteToTheSeries);
 
+                    } catch (DailyLimitExceededException e) {
+                        throw e;
                     } catch (Exception e) {
                         log.warn("Exception from " + webDataFeed.getSource(), e);
                     }
@@ -180,6 +185,8 @@ public class IntelligentStockFeed extends AbstractStockFeed implements StockFeed
                 try {
                     webdata = this.getDataIfFeedAvailable(instrument, fromDate, toDate, webDataFeed,
                             refresh, addLatestQuoteToTheSeries);
+                } catch (DailyLimitExceededException e) {
+                    throw e;
                 } catch (Exception e) {
                     log.warn("Exception from " + webDataFeed.getSource(), e);
                 }
@@ -205,7 +212,7 @@ public class IntelligentStockFeed extends AbstractStockFeed implements StockFeed
     }
 
     public Optional<StockV1> get(final Instrument instrument, final String fromDate, final String toDate,
-                                 final boolean interpolate, boolean cleanData, boolean addLatestQuoteToTheSeries) {
+                                 final boolean interpolate, boolean cleanData, boolean addLatestQuoteToTheSeries) throws IOException {
         return this.get(instrument, LocalDate.parse(fromDate), LocalDate.parse(toDate), interpolate, cleanData, addLatestQuoteToTheSeries);
     }
 

--- a/timeseries-stockfeed/src/main/java/com/leonarduk/finance/stockfeed/feed/stooq/DailyLimitExceededException.java
+++ b/timeseries-stockfeed/src/main/java/com/leonarduk/finance/stockfeed/feed/stooq/DailyLimitExceededException.java
@@ -1,0 +1,9 @@
+package com.leonarduk.finance.stockfeed.feed.stooq;
+
+import java.io.IOException;
+
+public class DailyLimitExceededException extends IOException {
+    public DailyLimitExceededException(String message) {
+        super(message);
+    }
+}

--- a/timeseries-stockfeed/src/test/java/com/leonarduk/finance/stockfeed/feed/stooq/StooqFeedLimiterTest.java
+++ b/timeseries-stockfeed/src/test/java/com/leonarduk/finance/stockfeed/feed/stooq/StooqFeedLimiterTest.java
@@ -1,0 +1,134 @@
+package com.leonarduk.finance.stockfeed.feed.stooq;
+
+import com.github.kevinsawicki.http.HttpRequest;
+import com.leonarduk.finance.stockfeed.Instrument;
+import com.leonarduk.finance.stockfeed.IntelligentStockFeed;
+import com.leonarduk.finance.stockfeed.DataStore;
+import com.leonarduk.finance.stockfeed.StockFeed;
+import com.leonarduk.finance.stockfeed.StockFeedFactory;
+import com.leonarduk.finance.stockfeed.feed.yahoofinance.StockV1;
+import com.leonarduk.finance.stockfeed.Source;
+import com.leonarduk.finance.stockfeed.CachedStockFeed;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.time.LocalDate;
+
+public class StooqFeedLimiterTest {
+
+    @Before
+    public void setup() {
+        StooqFeed.setDailyLimit(2);
+        StooqFeed.resetDailyLimitCounter();
+    }
+
+    @Test(expected = DailyLimitExceededException.class)
+    public void testLimitExceeded() throws IOException {
+        TestStooqFeed feed = new TestStooqFeed();
+        feed.get(Instrument.fromString("AAA"), LocalDate.now().minusDays(1), LocalDate.now(), false);
+        feed.get(Instrument.fromString("BBB"), LocalDate.now().minusDays(1), LocalDate.now(), false);
+        feed.get(Instrument.fromString("CCC"), LocalDate.now().minusDays(1), LocalDate.now(), false);
+    }
+
+    @Test(expected = DailyLimitExceededException.class)
+    public void testIntelligentFeedPropagatesError() throws Exception {
+        StooqFeed.setDailyLimit(0);
+        StooqFeed.resetDailyLimitCounter();
+        DummyDataStore ds = new DummyDataStore();
+        IntelligentStockFeed feed = new IntelligentStockFeed(ds);
+        TestStooqFeed stooq = new TestStooqFeed();
+        TestStockFeedFactory factory = new TestStockFeedFactory(ds, stooq);
+        java.lang.reflect.Field field = IntelligentStockFeed.class.getDeclaredField("stockFeedFactory");
+        field.setAccessible(true);
+        field.set(feed, factory);
+        feed.get(Instrument.fromString("AAA"), 1, false, false, false);
+    }
+
+    private static class TestStooqFeed extends StooqFeed {
+        @Override
+        protected HttpRequest createRequest(CharSequence uri) {
+            try {
+                return new DummyHttpRequest();
+            } catch (HttpRequest.HttpRequestException e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+
+    private static class DummyHttpRequest extends HttpRequest {
+        protected DummyHttpRequest() throws HttpRequest.HttpRequestException {
+            super("http://localhost", "GET");
+        }
+
+        @Override
+        public boolean ok() {
+            return true;
+        }
+
+        @Override
+        public int code() {
+            return 200;
+        }
+
+        @Override
+        public String body() {
+            return "date,open,high,low,close,volume\n2020-01-01,1,1,1,1,100\n";
+        }
+    }
+
+    private static class DummyDataStore implements DataStore {
+        @Override
+        public void storeSeries(StockV1 stock) {}
+
+        @Override
+        public boolean isAvailable() { return false; }
+
+        @Override
+        public java.util.Optional<StockV1> get(Instrument instrument, int years, boolean addLatest) { return java.util.Optional.empty(); }
+
+        @Override
+        public java.util.Optional<StockV1> get(Instrument instrument, LocalDate fromDate, LocalDate toDate, boolean addLatest) { return java.util.Optional.empty(); }
+
+        @Override
+        public boolean contains(StockV1 stock) { return false; }
+    }
+
+    private static class StubStockFeed implements StockFeed {
+        private final Source source;
+        StubStockFeed(Source source) { this.source = source; }
+        @Override
+        public java.util.Optional<StockV1> get(Instrument fromString, int i, boolean addLatestQuoteToTheSeries) throws IOException { return java.util.Optional.empty(); }
+        @Override
+        public java.util.Optional<StockV1> get(Instrument instrument, int years, boolean interpolate, boolean cleanData, boolean addLatestQuoteToTheSeries) throws IOException { return java.util.Optional.empty(); }
+        @Override
+        public java.util.Optional<StockV1> get(Instrument instrument, LocalDate fromDate, LocalDate toDate, boolean addLatestQuoteToTheSeries) throws IOException { return java.util.Optional.empty(); }
+        @Override
+        public java.util.Optional<StockV1> get(Instrument instrument, LocalDate fromLocalDate, LocalDate toLocalDate, boolean interpolate, boolean cleanData, boolean addLatestQuoteToTheSeries) throws IOException { return java.util.Optional.empty(); }
+        @Override
+        public Source getSource() { return source; }
+        @Override
+        public boolean isAvailable() { return false; }
+    }
+
+    private static class TestStockFeedFactory extends StockFeedFactory {
+        private final DataStore ds;
+        private final StockFeed stooq;
+        TestStockFeedFactory(DataStore ds, StockFeed stooq) {
+            super(ds);
+            this.ds = ds;
+            this.stooq = stooq;
+        }
+        @Override
+        public StockFeed getDataFeed(final Source source) {
+            switch (source) {
+                case MANUAL:
+                    return new CachedStockFeed(ds);
+                case STOOQ:
+                    return stooq;
+                default:
+                    return new StubStockFeed(source);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add in-memory request counting and caching to StooqFeed with daily reset and dedicated `DailyLimitExceededException`
- propagate request limit errors through `IntelligentStockFeed`
- introduce unit tests to ensure limiter and error propagation work

## Testing
- `mvn -q -pl timeseries-stockfeed test` *(fails: Non-resolvable parent POM: spring-boot-starter-parent:3.5.3)*

------
https://chatgpt.com/codex/tasks/task_e_689fbb8972248327a27a7e25afe6fe53