### PR TITLE
Add Hibernate Validator dependency and integration test

### DIFF
--- a/timeseries-spring-boot-server/pom.xml
+++ b/timeseries-spring-boot-server/pom.xml
@@ -58,6 +58,10 @@
                         <groupId>org.springframework.boot</groupId>
                         <artifactId>spring-boot-starter-mail</artifactId>
                 </dependency>
+                <dependency>
+                        <groupId>org.hibernate.validator</groupId>
+                        <artifactId>hibernate-validator</artifactId>
+                </dependency>
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>

--- a/timeseries-spring-boot-server/src/test/java/com/leonarduk/finance/springboot/validation/ValidatorIntegrationTest.java
+++ b/timeseries-spring-boot-server/src/test/java/com/leonarduk/finance/springboot/validation/ValidatorIntegrationTest.java
@@ -1,0 +1,31 @@
+package com.leonarduk.finance.springboot.validation;
+
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validator;
+import jakarta.validation.constraints.NotNull;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@SpringBootTest
+class ValidatorIntegrationTest {
+
+    static class SampleBean {
+        @NotNull
+        private String value;
+    }
+
+    @Autowired
+    private Validator validator;
+
+    @Test
+    void validatesConstraints() {
+        SampleBean bean = new SampleBean();
+        Set<ConstraintViolation<SampleBean>> violations = validator.validate(bean);
+        assertEquals(1, violations.size());
+    }
+}


### PR DESCRIPTION
## Summary
- Add Jakarta 3.x Hibernate Validator dependency to timeseries Spring Boot server
- Introduce integration test to verify bean validation with provider

## Testing
- `mvn -pl timeseries-spring-boot-server test -q` *(fails: Non-resolvable parent POM org.springframework.boot:spring-boot-starter-parent:3.5.3, Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689fbb8578e48327ba9399d50eaaf501