### PR TITLE
chore: exclude commons-logging from batik dependencies

### DIFF
--- a/timeseries-spring-boot-server/pom.xml
+++ b/timeseries-spring-boot-server/pom.xml
@@ -38,17 +38,29 @@
 
 	<dependencies>
 		<!-- https://mvnrepository.com/artifact/org.apache.xmlgraphics/batik-transcoder -->
-		<dependency>
-			<groupId>org.apache.xmlgraphics</groupId>
-			<artifactId>batik-transcoder</artifactId>
-			<version>1.19</version>
-		</dependency>
-		<!-- https://mvnrepository.com/artifact/org.apache.xmlgraphics/batik-codec -->
-		<dependency>
-			<groupId>org.apache.xmlgraphics</groupId>
-			<artifactId>batik-codec</artifactId>
-			<version>1.19</version>
-		</dependency>
+                <dependency>
+                        <groupId>org.apache.xmlgraphics</groupId>
+                        <artifactId>batik-transcoder</artifactId>
+                        <version>1.19</version>
+                        <exclusions>
+                                <exclusion>
+                                        <groupId>commons-logging</groupId>
+                                        <artifactId>commons-logging</artifactId>
+                                </exclusion>
+                        </exclusions>
+                </dependency>
+                <!-- https://mvnrepository.com/artifact/org.apache.xmlgraphics/batik-codec -->
+                <dependency>
+                        <groupId>org.apache.xmlgraphics</groupId>
+                        <artifactId>batik-codec</artifactId>
+                        <version>1.19</version>
+                        <exclusions>
+                                <exclusion>
+                                        <groupId>commons-logging</groupId>
+                                        <artifactId>commons-logging</artifactId>
+                                </exclusion>
+                        </exclusions>
+                </dependency>
 
                 <dependency>
                         <groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
## Summary
- exclude commons-logging from Batik transcoder and codec dependencies to avoid pulling the legacy logging jar

## Testing
- `mvn dependency:tree -Dincludes=commons-logging:commons-logging` *(fails: Non-resolvable parent POM: org.springframework.boot:spring-boot-starter-parent:3.5.3)*
- `mvn spring-boot:run` *(fails: Non-resolvable parent POM: org.springframework.boot:spring-boot-starter-parent:3.5.3)*

------
https://chatgpt.com/codex/tasks/task_e_689fbb8452108327b638698bf84d0cf4