### PR TITLE
Add tests for portfolio metrics summary

### DIFF
--- a/timeseries-spring-boot-server/src/main/java/com/leonarduk/finance/springboot/service/PortfolioMetricsService.java
+++ b/timeseries-spring-boot-server/src/main/java/com/leonarduk/finance/springboot/service/PortfolioMetricsService.java
@@ -1,5 +1,6 @@
 package com.leonarduk.finance.springboot.service;
 
+import java.time.Clock;
 import java.time.Instant;
 import org.springframework.stereotype.Service;
 
@@ -9,13 +10,23 @@ import org.springframework.stereotype.Service;
 @Service
 public class PortfolioMetricsService {
 
+    private final Clock clock;
+
+    public PortfolioMetricsService() {
+        this(Clock.systemUTC());
+    }
+
+    public PortfolioMetricsService(Clock clock) {
+        this.clock = clock;
+    }
+
     /**
      * Compile a simple summary of current portfolio metrics.
      *
      * @return summary text
      */
     public String createSummary() {
-        return "Portfolio metrics summary generated at " + Instant.now();
+        return "Portfolio metrics summary generated at " + Instant.now(this.clock);
     }
 }
 

--- a/timeseries-spring-boot-server/src/test/java/com/leonarduk/finance/springboot/service/PortfolioMetricsServiceTest.java
+++ b/timeseries-spring-boot-server/src/test/java/com/leonarduk/finance/springboot/service/PortfolioMetricsServiceTest.java
@@ -1,0 +1,38 @@
+package com.leonarduk.finance.springboot.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import org.junit.jupiter.api.Test;
+
+class PortfolioMetricsServiceTest {
+
+    @Test
+    void createSummaryIncludesTimestamp() {
+        PortfolioMetricsService service = new PortfolioMetricsService();
+        String summary = service.createSummary();
+        assertTrue(summary.startsWith("Portfolio metrics summary generated at "));
+        String timestamp = summary.substring("Portfolio metrics summary generated at ".length());
+        assertDoesNotThrow(() -> Instant.parse(timestamp));
+    }
+
+    @Test
+    void createSummaryUsesFixedClock() {
+        Instant fixedInstant = Instant.parse("2020-01-01T00:00:00Z");
+        Clock clock = Clock.fixed(fixedInstant, ZoneOffset.UTC);
+        PortfolioMetricsService service = new PortfolioMetricsService(clock);
+        String summary = service.createSummary();
+        assertEquals("Portfolio metrics summary generated at " + fixedInstant, summary);
+    }
+
+    @Test
+    void createSummaryAtEpoch() {
+        Instant fixedInstant = Instant.EPOCH;
+        Clock clock = Clock.fixed(fixedInstant, ZoneOffset.UTC);
+        PortfolioMetricsService service = new PortfolioMetricsService(clock);
+        String summary = service.createSummary();
+        assertEquals("Portfolio metrics summary generated at " + fixedInstant, summary);
+    }
+}


### PR DESCRIPTION
## Summary
- inject configurable Clock into `PortfolioMetricsService`
- add unit tests verifying timestamp formatting and behavior with fixed clock and epoch

## Testing
- `mvn -q -pl timeseries-spring-boot-server -am -Djava.net.preferIPv4Stack=true test` *(fails: Non-resolvable parent POM: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.5.3)*

------
https://chatgpt.com/codex/tasks/task_e_68a024d60bb48327b30628266aecb712