### PR TITLE
Add unit tests for AlphaVantage wrappers

### DIFF
--- a/alphavantage4j/src/test/java/org/patriques/ForeignExchangeTest.java
+++ b/alphavantage4j/src/test/java/org/patriques/ForeignExchangeTest.java
@@ -1,0 +1,57 @@
+package org.patriques;
+
+import org.junit.Test;
+import org.patriques.input.timeseries.OutputSize;
+import org.patriques.output.AlphaVantageException;
+import org.patriques.output.exchange.CurrencyExchange;
+import org.patriques.output.exchange.Daily;
+import org.patriques.output.exchange.data.CurrencyExchangeData;
+import org.patriques.output.exchange.data.ForexData;
+import org.patriques.input.ApiParameter;
+
+import static org.junit.Assert.*;
+
+public class ForeignExchangeTest {
+
+    private static final String ERROR_JSON = "{\"Error Message\":\"Test error\"}";
+
+    private ApiConnector connectorWith(final String json) {
+        return (ApiParameter... params) -> json;
+    }
+
+    @Test
+    public void testCurrencyExchangeRateSuccess() {
+        String json = "{\"Realtime Currency Exchange Rate\":{" +
+                "\"1. From_Currency Code\":\"USD\",\"2. From_Currency Name\":\"United States Dollar\"," +
+                "\"3. To_Currency Code\":\"JPY\",\"4. To_Currency Name\":\"Japanese Yen\"," +
+                "\"5. Exchange Rate\":\"110.00\",\"6. Last Refreshed\":\"2024-01-01 00:00:00\",\"7. Time Zone\":\"UTC\"}}";
+        ForeignExchange fx = new ForeignExchange(connectorWith(json));
+        CurrencyExchange ce = fx.currencyExchangeRate("USD", "JPY");
+        CurrencyExchangeData data = ce.getData();
+        assertEquals("USD", data.getFromCurrencyCode());
+        assertEquals(110.00f, data.getExchangeRate(), 0.0f);
+    }
+
+    @Test(expected = AlphaVantageException.class)
+    public void testCurrencyExchangeRateError() {
+        ForeignExchange fx = new ForeignExchange(connectorWith(ERROR_JSON));
+        fx.currencyExchangeRate("USD", "JPY");
+    }
+
+    @Test
+    public void testDailySuccess() {
+        String json = "{\"Meta Data\":{\"1. Information\":\"test\"}," +
+                "\"Time Series FX (Daily)\":{\"2024-01-01\":{\"1. open\":\"1.0\",\"2. high\":\"1.1\",\"3. low\":\"0.9\",\"4. close\":\"1.0\"}}}";
+        ForeignExchange fx = new ForeignExchange(connectorWith(json));
+        Daily daily = fx.daily("EUR", "USD", OutputSize.COMPACT);
+        ForexData data = daily.getForexData().get(0);
+        assertEquals(1.0, data.getOpen(), 0.0);
+    }
+
+    @Test(expected = AlphaVantageException.class)
+    public void testDailyError() {
+        ForeignExchange fx = new ForeignExchange(connectorWith(ERROR_JSON));
+        fx.daily("EUR", "USD", OutputSize.COMPACT);
+    }
+}
+

--- a/alphavantage4j/src/test/java/org/patriques/TechnicalIndicatorsTest.java
+++ b/alphavantage4j/src/test/java/org/patriques/TechnicalIndicatorsTest.java
@@ -1,0 +1,55 @@
+package org.patriques;
+
+import org.junit.Test;
+import org.patriques.input.technicalindicators.Interval;
+import org.patriques.input.technicalindicators.SeriesType;
+import org.patriques.input.ApiParameter;
+import org.patriques.output.AlphaVantageException;
+import org.patriques.output.technicalindicators.*;
+import org.patriques.output.technicalindicators.data.IndicatorData;
+
+import static org.junit.Assert.*;
+
+public class TechnicalIndicatorsTest {
+
+    private static final String ERROR_JSON = "{\"Error Message\":\"Test error\"}";
+
+    private ApiConnector connectorWith(final String json) {
+        return (ApiParameter... params) -> json;
+    }
+
+    @Test
+    public void testAdSuccess() {
+        String json = "{\"Meta Data\":{\"1: Symbol\":\"IBM\"}," +
+                "\"Technical Analysis: Chaikin A/D\":{\"2024-01-01\":{\"Chaikin A/D\":\"10.0\"}}}";
+        TechnicalIndicators ti = new TechnicalIndicators(connectorWith(json));
+        AD ad = ti.ad("IBM", Interval.DAILY);
+        IndicatorData data = ad.getData().get(0);
+        assertEquals(10.0, data.getData(), 0.0);
+    }
+
+    @Test(expected = AlphaVantageException.class)
+    public void testAdError() {
+        TechnicalIndicators ti = new TechnicalIndicators(connectorWith(ERROR_JSON));
+        ti.ad("IBM", Interval.DAILY);
+    }
+
+    @Test
+    public void testAdoscWithOptionalParameters() {
+        String json = "{\"Meta Data\":{\"1: Symbol\":\"IBM\"}," +
+                "\"Technical Analysis: ADOSC\":{\"2024-01-01\":{\"ADOSC\":\"10.0\"}}}";
+        TechnicalIndicators ti = new TechnicalIndicators(connectorWith(json));
+        ADOSC adosc = ti.adosc("IBM", Interval.DAILY, null, null);
+        assertEquals(10.0, adosc.getData().get(0).getData(), 0.0);
+    }
+
+    @Test
+    public void testApoWithOptionalParameters() {
+        String json = "{\"Meta Data\":{\"1: Symbol\":\"IBM\"}," +
+                "\"Technical Analysis: APO\":{\"2024-01-01\":{\"APO\":\"10.0\"}}}";
+        TechnicalIndicators ti = new TechnicalIndicators(connectorWith(json));
+        APO apo = ti.apo("IBM", Interval.DAILY, SeriesType.CLOSE, null, null, null);
+        assertEquals(10.0, apo.getData().get(0).getData(), 0.0);
+    }
+}
+

--- a/alphavantage4j/src/test/java/org/patriques/TimeSeriesTest.java
+++ b/alphavantage4j/src/test/java/org/patriques/TimeSeriesTest.java
@@ -1,0 +1,143 @@
+package org.patriques;
+
+import org.junit.Test;
+import org.patriques.input.timeseries.Interval;
+import org.patriques.input.timeseries.OutputSize;
+import org.patriques.input.ApiParameter;
+import org.patriques.output.AlphaVantageException;
+import org.patriques.output.timeseries.*;
+import org.patriques.output.timeseries.data.StockData;
+
+
+import static org.junit.Assert.*;
+
+public class TimeSeriesTest {
+
+    private static final String ERROR_JSON = "{\"Error Message\":\"Test error\"}";
+
+    private ApiConnector connectorWith(final String json) {
+        return (ApiParameter... params) -> json;
+    }
+
+    @Test
+    public void testIntraDayWithAndWithoutOutputSize() {
+        String json = "{\"Meta Data\":{\"1. Information\":\"test\"}," +
+                "\"Time Series (1min)\":{\"2024-01-01 00:00:00\":{" +
+                "\"1. open\":\"1.0\",\"2. high\":\"1.1\",\"3. low\":\"0.9\",\"4. close\":\"1.0\",\"5. volume\":\"1000\"}}}";
+        TimeSeries ts = new TimeSeries(connectorWith(json));
+        IntraDay result = ts.intraDay("IBM", Interval.ONE_MIN, OutputSize.COMPACT);
+        assertEquals("test", result.getMetaData().get("1. Information"));
+        StockData data = result.getStockData().get(0);
+        assertEquals(1.0, data.getOpen(), 0.0);
+        // call overloaded method without output size
+        result = ts.intraDay("IBM", Interval.ONE_MIN);
+        assertNotNull(result.getStockData());
+    }
+
+    @Test(expected = AlphaVantageException.class)
+    public void testIntraDayError() {
+        TimeSeries ts = new TimeSeries(connectorWith(ERROR_JSON));
+        ts.intraDay("IBM", Interval.ONE_MIN);
+    }
+
+    @Test
+    public void testDailyWithAndWithoutOutputSize() {
+        String json = "{\"Meta Data\":{\"1. Information\":\"test\"}," +
+                "\"Time Series (Daily)\":{\"2024-01-01\":{\"1. open\":\"1.0\",\"2. high\":\"1.1\",\"3. low\":\"0.9\",\"4. close\":\"1.0\",\"5. volume\":\"1000\"}}}";
+        TimeSeries ts = new TimeSeries(connectorWith(json));
+        Daily daily = ts.daily("IBM", OutputSize.COMPACT);
+        assertEquals(1.0, daily.getStockData().get(0).getOpen(), 0.0);
+        daily = ts.daily("IBM");
+        assertEquals(1.0, daily.getStockData().get(0).getOpen(), 0.0);
+    }
+
+    @Test(expected = AlphaVantageException.class)
+    public void testDailyError() {
+        TimeSeries ts = new TimeSeries(connectorWith(ERROR_JSON));
+        ts.daily("IBM");
+    }
+
+    @Test
+    public void testDailyAdjustedWithAndWithoutOutputSize() {
+        String json = "{\"Meta Data\":{\"1. Information\":\"test\"}," +
+                "\"Time Series (Daily)\":{\"2024-01-01\":{" +
+                "\"1. open\":\"1.0\",\"2. high\":\"1.1\",\"3. low\":\"0.9\",\"4. close\":\"1.0\"," +
+                "\"5. adjusted close\":\"1.0\",\"6. volume\":\"1000\",\"7. dividend amount\":\"0.0\",\"8. split coefficient\":\"1.0\"}}}";
+        TimeSeries ts = new TimeSeries(connectorWith(json));
+        DailyAdjusted da = ts.dailyAdjusted("IBM", OutputSize.COMPACT);
+        assertEquals(1.0, da.getStockData().get(0).getAdjustedClose(), 0.0);
+        da = ts.dailyAdjusted("IBM");
+        assertEquals(1.0, da.getStockData().get(0).getAdjustedClose(), 0.0);
+    }
+
+    @Test(expected = AlphaVantageException.class)
+    public void testDailyAdjustedError() {
+        TimeSeries ts = new TimeSeries(connectorWith(ERROR_JSON));
+        ts.dailyAdjusted("IBM");
+    }
+
+    @Test
+    public void testWeekly() {
+        String json = "{\"Meta Data\":{\"1. Information\":\"test\"}," +
+                "\"Weekly Time Series\":{\"2024-01-05\":{\"1. open\":\"1.0\",\"2. high\":\"1.1\",\"3. low\":\"0.9\",\"4. close\":\"1.0\",\"5. volume\":\"1000\"}}}";
+        TimeSeries ts = new TimeSeries(connectorWith(json));
+        Weekly weekly = ts.weekly("IBM");
+        assertEquals(1.0, weekly.getStockData().get(0).getOpen(), 0.0);
+    }
+
+    @Test(expected = AlphaVantageException.class)
+    public void testWeeklyError() {
+        TimeSeries ts = new TimeSeries(connectorWith(ERROR_JSON));
+        ts.weekly("IBM");
+    }
+
+    @Test
+    public void testWeeklyAdjusted() {
+        String json = "{\"Meta Data\":{\"1. Information\":\"test\"}," +
+                "\"Weekly Adjusted Time Series\":{\"2024-01-05\":{" +
+                "\"1. open\":\"1.0\",\"2. high\":\"1.1\",\"3. low\":\"0.9\",\"4. close\":\"1.0\"," +
+                "\"5. adjusted close\":\"1.0\",\"6. volume\":\"1000\",\"7. dividend amount\":\"0.0\"}}}";
+        TimeSeries ts = new TimeSeries(connectorWith(json));
+        WeeklyAdjusted wa = ts.weeklyAdjusted("IBM");
+        assertEquals(1.0, wa.getStockData().get(0).getAdjustedClose(), 0.0);
+    }
+
+    @Test(expected = AlphaVantageException.class)
+    public void testWeeklyAdjustedError() {
+        TimeSeries ts = new TimeSeries(connectorWith(ERROR_JSON));
+        ts.weeklyAdjusted("IBM");
+    }
+
+    @Test
+    public void testMonthly() {
+        String json = "{\"Meta Data\":{\"1. Information\":\"test\"}," +
+                "\"Monthly Time Series\":{\"2024-01-31\":{\"1. open\":\"1.0\",\"2. high\":\"1.1\",\"3. low\":\"0.9\",\"4. close\":\"1.0\",\"5. volume\":\"1000\"}}}";
+        TimeSeries ts = new TimeSeries(connectorWith(json));
+        Monthly monthly = ts.monthly("IBM");
+        assertEquals(1.0, monthly.getStockData().get(0).getOpen(), 0.0);
+    }
+
+    @Test(expected = AlphaVantageException.class)
+    public void testMonthlyError() {
+        TimeSeries ts = new TimeSeries(connectorWith(ERROR_JSON));
+        ts.monthly("IBM");
+    }
+
+    @Test
+    public void testMonthlyAdjusted() {
+        String json = "{\"Meta Data\":{\"1. Information\":\"test\"}," +
+                "\"Monthly Adjusted Time Series\":{\"2024-01-31\":{" +
+                "\"1. open\":\"1.0\",\"2. high\":\"1.1\",\"3. low\":\"0.9\",\"4. close\":\"1.0\"," +
+                "\"5. adjusted close\":\"1.0\",\"6. volume\":\"1000\",\"7. dividend amount\":\"0.0\"}}}";
+        TimeSeries ts = new TimeSeries(connectorWith(json));
+        MonthlyAdjusted ma = ts.monthlyAdjusted("IBM");
+        assertEquals(1.0, ma.getStockData().get(0).getAdjustedClose(), 0.0);
+    }
+
+    @Test(expected = AlphaVantageException.class)
+    public void testMonthlyAdjustedError() {
+        TimeSeries ts = new TimeSeries(connectorWith(ERROR_JSON));
+        ts.monthlyAdjusted("IBM");
+    }
+}
+


### PR DESCRIPTION
## Summary
- Add coverage for TimeSeries API, including optional parameters and error paths
- Add tests for TechnicalIndicators AD/ADOSC/APO parsing
- Add tests for ForeignExchange currency rates and daily series

## Testing
- `mvn -q -f alphavantage4j/pom.xml test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 not resolved, network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a024d3f6e083278c53fac1de334bc0