### PR TITLE
Add unit tests for feed interfaces and factory behavior

### DIFF
--- a/timeseries-stockfeed/pom.xml
+++ b/timeseries-stockfeed/pom.xml
@@ -33,5 +33,11 @@
             <artifactId>ta4j-core</artifactId>
             <version>${org.ta4j.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>5.11.0</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/timeseries-stockfeed/src/test/java/com/leonarduk/finance/stockfeed/CachedStockFeedTest.java
+++ b/timeseries-stockfeed/src/test/java/com/leonarduk/finance/stockfeed/CachedStockFeedTest.java
@@ -1,0 +1,82 @@
+package com.leonarduk.finance.stockfeed;
+
+import com.leonarduk.finance.stockfeed.feed.ExtendedHistoricalQuote;
+import com.leonarduk.finance.stockfeed.feed.yahoofinance.StockV1;
+import org.junit.Assert;
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.ta4j.core.Bar;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+public class CachedStockFeedTest {
+
+    @Test
+    public void testLoadSeriesReturnsCachedData() throws Exception {
+        DataStore store = Mockito.mock(DataStore.class);
+        CachedStockFeed feed = new CachedStockFeed(store);
+        Instrument instrument = new FxInstrument(Source.MANUAL, "USD", "GBP");
+        List<Bar> history = List.of(
+                new ExtendedHistoricalQuote(instrument, LocalDate.now().minusDays(1), 1d, 1d, 1d, 1d, 1d, 0L, "orig"));
+        StockV1 cached = new StockV1(instrument, history);
+        Mockito.when(store.get(instrument, 1000, false)).thenReturn(Optional.of(cached));
+
+        List<Bar> result = feed.loadSeries(cached);
+
+        Assert.assertEquals(history, result);
+    }
+
+    @Test
+    public void testLoadSeriesReturnsEmptyWhenCacheMiss() throws Exception {
+        DataStore store = Mockito.mock(DataStore.class);
+        CachedStockFeed feed = new CachedStockFeed(store);
+        Instrument instrument = new FxInstrument(Source.MANUAL, "USD", "GBP");
+        StockV1 stock = new StockV1(instrument, List.of());
+        Mockito.when(store.get(instrument, 1000, false)).thenReturn(Optional.empty());
+
+        List<Bar> result = feed.loadSeries(stock);
+
+        Assert.assertTrue(result.isEmpty());
+    }
+
+    @Test
+    public void testStoreSeriesMergesExistingData() throws Exception {
+        DataStore store = Mockito.mock(DataStore.class);
+        CachedStockFeed feed = new CachedStockFeed(store);
+        Instrument instrument = new FxInstrument(Source.MANUAL, "USD", "GBP");
+
+        List<Bar> originalHistory = List.of(
+                new ExtendedHistoricalQuote(instrument, LocalDate.now().minusDays(2), 1d, 1d, 1d, 1d, 1d, 0L, "orig"));
+        StockV1 originalStock = new StockV1(instrument, originalHistory);
+
+        List<Bar> newHistory = List.of(
+                new ExtendedHistoricalQuote(instrument, LocalDate.now().minusDays(1), 2d, 2d, 2d, 2d, 2d, 0L, "new"));
+        StockV1 newStock = new StockV1(instrument, newHistory);
+
+        Mockito.when(store.contains(newStock)).thenReturn(true);
+        Mockito.when(store.get(instrument, 1000, false)).thenReturn(Optional.of(originalStock));
+
+        feed.storeSeries(newStock);
+
+        Mockito.verify(store).storeSeries(newStock);
+        Assert.assertEquals(2, newStock.getHistory().size());
+    }
+
+    @Test
+    public void testStoreSeriesWithoutExistingData() throws Exception {
+        DataStore store = Mockito.mock(DataStore.class);
+        CachedStockFeed feed = new CachedStockFeed(store);
+        Instrument instrument = new FxInstrument(Source.MANUAL, "USD", "GBP");
+        StockV1 stock = new StockV1(instrument, List.of());
+
+        Mockito.when(store.contains(stock)).thenReturn(false);
+
+        feed.storeSeries(stock);
+
+        Mockito.verify(store).storeSeries(stock);
+        Mockito.verify(store, Mockito.never()).get(Mockito.<Instrument>any(), Mockito.anyInt(), Mockito.anyBoolean());
+    }
+}
+

--- a/timeseries-stockfeed/src/test/java/com/leonarduk/finance/stockfeed/FxFeedTest.java
+++ b/timeseries-stockfeed/src/test/java/com/leonarduk/finance/stockfeed/FxFeedTest.java
@@ -1,0 +1,41 @@
+package com.leonarduk.finance.stockfeed;
+
+import com.leonarduk.finance.stockfeed.feed.ExtendedHistoricalQuote;
+import org.junit.Assert;
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.ta4j.core.Bar;
+
+import java.time.LocalDate;
+import java.util.Collections;
+import java.util.List;
+
+public class FxFeedTest {
+
+    @Test
+    public void testGetFxSeriesReturnsData() {
+        FxFeed mockFeed = Mockito.mock(FxFeed.class);
+        LocalDate from = LocalDate.now().minusDays(1);
+        LocalDate to = LocalDate.now();
+        Instrument instrument = new FxInstrument(Source.MANUAL, "USD", "GBP");
+        List<Bar> series = List.of(
+                new ExtendedHistoricalQuote(instrument, from, 1d, 1d, 1d, 1d, 1d, 0L, "test"),
+                new ExtendedHistoricalQuote(instrument, to, 1d, 1d, 1d, 1d, 1d, 0L, "test"));
+        Mockito.when(mockFeed.getFxSeries("USD", "GBP", from, to)).thenReturn(series);
+
+        List<Bar> result = mockFeed.getFxSeries("USD", "GBP", from, to);
+        Assert.assertEquals(series, result);
+    }
+
+    @Test
+    public void testGetFxSeriesUnknownPairReturnsEmptyList() {
+        FxFeed mockFeed = Mockito.mock(FxFeed.class);
+        LocalDate from = LocalDate.now().minusDays(1);
+        LocalDate to = LocalDate.now();
+        Mockito.when(mockFeed.getFxSeries("AAA", "BBB", from, to)).thenReturn(Collections.emptyList());
+
+        List<Bar> result = mockFeed.getFxSeries("AAA", "BBB", from, to);
+        Assert.assertTrue(result.isEmpty());
+    }
+}
+

--- a/timeseries-stockfeed/src/test/java/com/leonarduk/finance/stockfeed/StockFeedFactoryTest.java
+++ b/timeseries-stockfeed/src/test/java/com/leonarduk/finance/stockfeed/StockFeedFactoryTest.java
@@ -1,0 +1,58 @@
+package com.leonarduk.finance.stockfeed;
+
+import com.leonarduk.finance.stockfeed.feed.alphavantage.AlphavantageFeed;
+import com.leonarduk.finance.stockfeed.feed.ft.FTFeed;
+import com.leonarduk.finance.stockfeed.feed.stooq.StooqFeed;
+import org.junit.Assert;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.lang.reflect.Field;
+
+public class StockFeedFactoryTest {
+
+    @Test
+    public void testManualSourceUsesProvidedDataStore() {
+        DataStore dataStore = Mockito.mock(DataStore.class);
+        Mockito.when(dataStore.isAvailable()).thenReturn(true);
+        StockFeedFactory factory = new StockFeedFactory(dataStore);
+
+        StockFeed feed = factory.getDataFeed(Source.MANUAL);
+
+        Assert.assertTrue(feed instanceof CachedStockFeed);
+        Mockito.verify(dataStore).isAvailable();
+    }
+
+    @Test
+    public void testManualSourceFallsBackWhenDataStoreUnavailable() throws Exception {
+        DataStore dataStore = Mockito.mock(DataStore.class);
+        Mockito.when(dataStore.isAvailable()).thenReturn(false);
+        StockFeedFactory factory = new StockFeedFactory(dataStore);
+
+        StockFeed feed = factory.getDataFeed(Source.MANUAL);
+
+        Assert.assertTrue(feed instanceof CachedStockFeed);
+
+        Field field = CachedStockFeed.class.getDeclaredField("dataStore");
+        field.setAccessible(true);
+        DataStore used = (DataStore) field.get(feed);
+        Assert.assertNotSame(dataStore, used);
+    }
+
+    @Test
+    public void testReturnsSpecificFeedsForSources() {
+        StockFeedFactory factory = new StockFeedFactory(Mockito.mock(DataStore.class));
+
+        Assert.assertTrue(factory.getDataFeed(Source.FT) instanceof FTFeed);
+        Assert.assertTrue(factory.getDataFeed(Source.ALPHAVANTAGE) instanceof AlphavantageFeed);
+        Assert.assertTrue(factory.getDataFeed(Source.STOOQ) instanceof StooqFeed);
+    }
+
+    @Test
+    public void testReturnsStooqFeedForUnknownSource() {
+        StockFeedFactory factory = new StockFeedFactory(Mockito.mock(DataStore.class));
+        StockFeed feed = factory.getDataFeed(Source.GOOGLE);
+        Assert.assertTrue(feed instanceof StooqFeed);
+    }
+}
+


### PR DESCRIPTION
## Summary
- add Mockito-based unit tests for FxFeed currency pairs
- cover CachedStockFeed caching scenarios and cache misses
- verify StockFeedFactory feed selection and fallback logic

## Testing
- `mvn -q -f timeseries-stockfeed/pom.xml test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 or one of its dependencies could not be resolved: Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin:pom:3.3.1 from/to central (https://repo.maven.apache.org/maven2): Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a024d50cf48327abf544dfa0b87901