### PR TITLE
Add tests for purchase/sales scripts and risk-return API

### DIFF
--- a/timeseries-python/tests/test_look_for_purchases.py
+++ b/timeseries-python/tests/test_look_for_purchases.py
@@ -1,0 +1,100 @@
+import os
+import sys
+import runpy
+import types
+import pandas as pd
+import pytest
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+
+def _stub_environment(monkeypatch, df):
+    """Create minimal stub modules so the script can run without heavy deps."""
+    positions_mod = types.ModuleType("integrations.portfolioperformance.api.positions")
+    positions_mod.extract_holdings_from_transactions = lambda *args, **kwargs: df
+
+    analyse_mod = types.ModuleType("analysis.instrument.analyse_instrument")
+    calls = {}
+
+    def fake_analyze_all_tickers(**kwargs):
+        calls["tickers"] = kwargs.get("tickers")
+
+    analyse_mod.analyze_all_tickers = fake_analyze_all_tickers
+
+    ftse_mod = types.ModuleType(
+        "integrations.portfolioperformance.api.static.ftse_all_share_dict"
+    )
+    ftse_mod.ftse_all_share = {"AAA": "AAA", "BBB": "BBB"}
+
+    sentiment_mod = types.ModuleType("analysis.sentiment.sentiment_timeseries")
+    sentiment_mod.analyse_sentiment = lambda *args, **kwargs: None
+
+    integrations_pkg = types.ModuleType("integrations")
+    integrations_pkg.__path__ = []
+    portfolio_pkg = types.ModuleType("integrations.portfolioperformance")
+    portfolio_pkg.__path__ = []
+    api_pkg = types.ModuleType("integrations.portfolioperformance.api")
+    api_pkg.__path__ = []
+    static_pkg = types.ModuleType("integrations.portfolioperformance.api.static")
+    static_pkg.__path__ = []
+    sentiment_pkg = types.ModuleType("analysis.sentiment")
+    sentiment_pkg.__path__ = []
+
+    monkeypatch.setitem(sys.modules, "integrations", integrations_pkg)
+    monkeypatch.setitem(sys.modules, "integrations.portfolioperformance", portfolio_pkg)
+    monkeypatch.setitem(sys.modules, "integrations.portfolioperformance.api", api_pkg)
+    monkeypatch.setitem(
+        sys.modules,
+        "integrations.portfolioperformance.api.positions",
+        positions_mod,
+    )
+    monkeypatch.setitem(
+        sys.modules, "integrations.portfolioperformance.api.static", static_pkg
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "integrations.portfolioperformance.api.static.ftse_all_share_dict",
+        ftse_mod,
+    )
+    monkeypatch.setitem(
+        sys.modules, "analysis.instrument.analyse_instrument", analyse_mod
+    )
+    monkeypatch.setitem(sys.modules, "analysis.sentiment", sentiment_pkg)
+    monkeypatch.setitem(
+        sys.modules, "analysis.sentiment.sentiment_timeseries", sentiment_mod
+    )
+    return calls
+
+
+@pytest.fixture
+def purchase_env(monkeypatch):
+    df = pd.DataFrame({"ticker": ["AAA.L"]})
+    return _stub_environment(monkeypatch, df)
+
+
+def test_look_for_purchases_calls_analyze_all_tickers(purchase_env):
+    calls = purchase_env
+    runpy.run_module("analysis.look_for_purchases", run_name="__main__")
+    assert calls["tickers"] == [
+        "CARD.L",
+        "HFEL.L",
+        "TFIF.L",
+        "ASLI.L",
+        "ERNS.L",
+        "GAW.L",
+        "HICL.L",
+    ]
+
+
+def test_look_for_purchases_handles_empty_dataset(monkeypatch):
+    df = pd.DataFrame({"ticker": []})
+    calls = _stub_environment(monkeypatch, df)
+    runpy.run_module("analysis.look_for_purchases", run_name="__main__")
+    assert "tickers" in calls
+
+
+def test_look_for_purchases_missing_ticker_column(monkeypatch):
+    df = pd.DataFrame({"not_ticker": []})
+    _stub_environment(monkeypatch, df)
+    with pytest.raises(KeyError):
+        runpy.run_module("analysis.look_for_purchases", run_name="__main__")

--- a/timeseries-python/tests/test_look_for_sales.py
+++ b/timeseries-python/tests/test_look_for_sales.py
@@ -1,0 +1,67 @@
+import os
+import sys
+import runpy
+import types
+import pandas as pd
+import pytest
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+
+def _stub_sales_env(monkeypatch, df):
+    positions_mod = types.ModuleType("integrations.portfolioperformance.api.positions")
+    positions_mod.extract_holdings_from_transactions = lambda *args, **kwargs: df
+
+    analyse_mod = types.ModuleType("analysis.instrument.analyse_instrument")
+    calls = {}
+
+    def fake_analyze_all_tickers(**kwargs):
+        calls["tickers"] = kwargs.get("tickers")
+
+    analyse_mod.analyze_all_tickers = fake_analyze_all_tickers
+
+    integrations_pkg = types.ModuleType("integrations")
+    integrations_pkg.__path__ = []
+    portfolio_pkg = types.ModuleType("integrations.portfolioperformance")
+    portfolio_pkg.__path__ = []
+    api_pkg = types.ModuleType("integrations.portfolioperformance.api")
+    api_pkg.__path__ = []
+
+    monkeypatch.setitem(sys.modules, "integrations", integrations_pkg)
+    monkeypatch.setitem(sys.modules, "integrations.portfolioperformance", portfolio_pkg)
+    monkeypatch.setitem(sys.modules, "integrations.portfolioperformance.api", api_pkg)
+    monkeypatch.setitem(
+        sys.modules,
+        "integrations.portfolioperformance.api.positions",
+        positions_mod,
+    )
+    monkeypatch.setitem(
+        sys.modules, "analysis.instrument.analyse_instrument", analyse_mod
+    )
+    return calls
+
+
+@pytest.fixture
+def sales_env(monkeypatch):
+    df = pd.DataFrame({"ticker": ["AAA.L", "BBB.L"]})
+    return _stub_sales_env(monkeypatch, df)
+
+
+def test_look_for_sales_passes_holdings_to_analyze_all_tickers(sales_env):
+    calls = sales_env
+    runpy.run_module("analysis.look_for_sales", run_name="__main__")
+    assert calls["tickers"] == ["AAA.L", "BBB.L"]
+
+
+def test_look_for_sales_handles_empty_dataset(monkeypatch):
+    df = pd.DataFrame({"ticker": []})
+    calls = _stub_sales_env(monkeypatch, df)
+    runpy.run_module("analysis.look_for_sales", run_name="__main__")
+    assert calls["tickers"] == []
+
+
+def test_look_for_sales_missing_ticker_column(monkeypatch):
+    df = pd.DataFrame({"other": []})
+    _stub_sales_env(monkeypatch, df)
+    with pytest.raises(KeyError):
+        runpy.run_module("analysis.look_for_sales", run_name="__main__")

--- a/timeseries-python/tests/test_risk_return_api.py
+++ b/timeseries-python/tests/test_risk_return_api.py
@@ -1,0 +1,63 @@
+import os
+import sys
+import pandas as pd
+import pytest
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import analysis.risk_return_api as api  # noqa: E402
+
+
+@pytest.fixture
+def client(monkeypatch):
+    def fake_risk_return(tickers, confidence_level=0.95):
+        return pd.DataFrame(
+            {
+                "ticker": tickers,
+                "annual_return": [0.1] * len(tickers),
+                "annual_std": [0.2] * len(tickers),
+            }
+        )
+
+    def fake_max_drawdown(tickers):
+        return pd.DataFrame({"ticker": tickers, "max_drawdown": [-0.3] * len(tickers)})
+
+    monkeypatch.setattr(api, "risk_return", fake_risk_return)
+    monkeypatch.setattr(api, "max_drawdown", fake_max_drawdown)
+    api.app.config["TESTING"] = False
+    return api.app.test_client()
+
+
+def test_risk_return_endpoint_returns_data(client):
+    resp = client.get("/analytics/risk-return?tickers=AAA,BBB&confidenceLevel=0.9")
+    assert resp.status_code == 200
+    assert resp.get_json() == [
+        {"ticker": "AAA", "annual_return": 0.1, "annual_std": 0.2},
+        {"ticker": "BBB", "annual_return": 0.1, "annual_std": 0.2},
+    ]
+
+
+def test_risk_return_endpoint_handles_missing_tickers(client):
+    resp = client.get("/analytics/risk-return")
+    assert resp.status_code == 200
+    assert resp.get_json() == []
+
+
+def test_risk_return_endpoint_invalid_confidence(client):
+    resp = client.get("/analytics/risk-return?tickers=AAA&confidenceLevel=bad")
+    assert resp.status_code == 500
+
+
+def test_max_drawdown_endpoint(client):
+    resp = client.get("/analytics/max-drawdown?tickers=AAA,BBB")
+    assert resp.status_code == 200
+    assert resp.get_json() == [
+        {"ticker": "AAA", "max_drawdown": -0.3},
+        {"ticker": "BBB", "max_drawdown": -0.3},
+    ]
+
+
+def test_max_drawdown_endpoint_handles_missing_tickers(client):
+    resp = client.get("/analytics/max-drawdown")
+    assert resp.status_code == 200
+    assert resp.get_json() == []


### PR DESCRIPTION
## Summary
- add fixture-driven tests for purchase and sales scripts
- cover risk-return and max-drawdown API endpoints
- exercise edge cases like empty datasets and invalid params

## Testing
- `pre-commit run --files timeseries-python/tests/test_look_for_purchases.py timeseries-python/tests/test_look_for_sales.py timeseries-python/tests/test_risk_return_api.py`
- `pytest timeseries-python/tests/test_look_for_purchases.py timeseries-python/tests/test_look_for_sales.py timeseries-python/tests/test_risk_return_api.py`


------
https://chatgpt.com/codex/tasks/task_e_68a024d029948327a4ba5a34c26e1ddc