### PR TITLE
fix: include end date in workday diff

### DIFF
--- a/timeseries-stockfeed/src/main/java/com/leonarduk/finance/utils/DateUtils.java
+++ b/timeseries-stockfeed/src/main/java/com/leonarduk/finance/utils/DateUtils.java
@@ -112,7 +112,9 @@ public class DateUtils {
 
         // Iterate over stream of all dates and check each day against any weekday or
         // holiday
-        List<LocalDate> businessDays = startDate.datesUntil(endDate)
+        // `datesUntil` excludes the final date. Include it to count the end date when
+        // it falls on a working day.
+        List<LocalDate> businessDays = startDate.datesUntil(endDate.plusDays(1))
                 .filter(isWeekend().or(isHoliday).negate())
                 .collect(Collectors.toList());
 

--- a/timeseries-stockfeed/src/test/java/com/leonarduk/finance/utils/DateUtilsTest.java
+++ b/timeseries-stockfeed/src/test/java/com/leonarduk/finance/utils/DateUtilsTest.java
@@ -19,20 +19,20 @@ public class DateUtilsTest {
     @Ignore
     public final void testGetDiffInWorkDays() {
 
-        Assert.assertEquals(2,
+        Assert.assertEquals(3,
                 DateUtils.getDiffInWorkDays(LocalDate.parse("2009-08-28"), LocalDate.parse("2009-09-01")));
 
-        Assert.assertEquals(7,
-                DateUtils.getDiffInWorkDays(LocalDate.parse(DateUtilsTest.APRIL3), LocalDate.parse("2017-04-12")));
-        Assert.assertEquals(1, DateUtils.getDiffInWorkDays(LocalDate.parse(DateUtilsTest.APRIL3),
-                LocalDate.parse(DateUtilsTest.APRIL4)));
-        Assert.assertEquals(5, DateUtils.getDiffInWorkDays(LocalDate.parse(DateUtilsTest.APRIL3),
-                LocalDate.parse(DateUtilsTest.APRIL10)));
-        Assert.assertEquals(6,
-                DateUtils.getDiffInWorkDays(LocalDate.parse(DateUtilsTest.APRIL3), LocalDate.parse("2017-04-11")));
         Assert.assertEquals(8,
+                DateUtils.getDiffInWorkDays(LocalDate.parse(DateUtilsTest.APRIL3), LocalDate.parse("2017-04-12")));
+        Assert.assertEquals(2, DateUtils.getDiffInWorkDays(LocalDate.parse(DateUtilsTest.APRIL3),
+                LocalDate.parse(DateUtilsTest.APRIL4)));
+        Assert.assertEquals(6, DateUtils.getDiffInWorkDays(LocalDate.parse(DateUtilsTest.APRIL3),
+                LocalDate.parse(DateUtilsTest.APRIL10)));
+        Assert.assertEquals(7,
+                DateUtils.getDiffInWorkDays(LocalDate.parse(DateUtilsTest.APRIL3), LocalDate.parse("2017-04-11")));
+        Assert.assertEquals(9,
                 DateUtils.getDiffInWorkDays(LocalDate.parse(DateUtilsTest.APRIL3), LocalDate.parse("2017-04-13")));
-        Assert.assertEquals(10,
+        Assert.assertEquals(11,
                 DateUtils.getDiffInWorkDays(LocalDate.parse(DateUtilsTest.APRIL3), LocalDate.parse("2017-04-17")));
     }
 
@@ -40,7 +40,7 @@ public class DateUtilsTest {
     public void testGetDiffInWorkDaysSkipsBankHolidays() {
         LocalDate start = LocalDate.parse("2023-04-28");
         LocalDate end = LocalDate.parse("2023-05-09");
-        Assert.assertEquals(5, DateUtils.getDiffInWorkDays(start, end));
+        Assert.assertEquals(6, DateUtils.getDiffInWorkDays(start, end));
     }
 
     @Test


### PR DESCRIPTION
## Summary
- count final day when computing business day difference
- update tests for new inclusive behaviour

## Testing
- `pytest timeseries-python/tests -q`
- `mvn -q test` *(fails: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.5.3: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a02a7e815883279b0e5ae9a35ccc96