### PR TITLE
fix: use valid Spring Boot parent version

### DIFF
--- a/timeseries-spring-boot-server/pom.xml
+++ b/timeseries-spring-boot-server/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.5.3</version>
+        <version>3.2.5</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
 


### PR DESCRIPTION
## Summary
- fix spring boot module to use existing parent POM version

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM... Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a0319ae0fc832795d56f48ccc859bb