### PR TITLE
feat(lambda): upload API results to S3

### DIFF
--- a/timeseries-lambda/pom.xml
+++ b/timeseries-lambda/pom.xml
@@ -69,6 +69,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>5.11.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>com.leonarduk</groupId>
             <artifactId>timeseries-stockfeed</artifactId>
             <version>0.1.3</version>

--- a/timeseries-lambda/src/main/java/com/leonarduk/aws/apigateway/ApiGatewayHandler.java
+++ b/timeseries-lambda/src/main/java/com/leonarduk/aws/apigateway/ApiGatewayHandler.java
@@ -1,12 +1,17 @@
 package com.leonarduk.aws.apigateway;
 
+import com.amazonaws.AmazonServiceException;
+import com.amazonaws.SdkClientException;
 import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.RequestHandler;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
 import com.leonarduk.aws.QueryRunner;
 
 import java.io.IOException;
+import java.util.Map;
 
 /**
  * Lambda function entry point. You can change to use other pojo type or implement
@@ -18,18 +23,37 @@ public class ApiGatewayHandler
         implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
 
     private final QueryRunner queryRunner;
+    private final AmazonS3 s3Client;
+    private final String resultBucket;
 
     public ApiGatewayHandler() {
+        this(AmazonS3ClientBuilder.standard().build(), System.getenv("RESULT_BUCKET"));
+    }
+
+    ApiGatewayHandler(AmazonS3 s3Client, String resultBucket) {
         this.queryRunner = new QueryRunner();
+        this.s3Client = s3Client;
+        this.resultBucket = resultBucket;
     }
 
     @Override
     public APIGatewayProxyResponseEvent handleRequest(final APIGatewayProxyRequestEvent input, final Context context) {
-        // TODO: invoking the api call using s3Client.
         APIGatewayProxyResponseEvent responseEvent = new APIGatewayProxyResponseEvent();
         try {
-            responseEvent.setBody(this.queryRunner.getResults(input.getQueryStringParameters()));
+            Map<String, String> params = input.getQueryStringParameters();
+            String result = this.queryRunner.getResults(params);
+
+            if (this.s3Client != null && this.resultBucket != null && !this.resultBucket.isBlank()) {
+                String ticker = params != null ? params.get(QueryRunner.TICKER) : "result";
+                String key = "results/" + (ticker != null ? ticker : "result") + ".html";
+                this.s3Client.putObject(this.resultBucket, key, result);
+            }
+
+            responseEvent.setBody(result);
             responseEvent.setStatusCode(200);
+        } catch (AmazonServiceException | SdkClientException e) {
+            responseEvent.setBody("S3_ERROR: " + e.getMessage());
+            responseEvent.setStatusCode(502);
         } catch (IOException e) {
             e.printStackTrace();
             responseEvent.setBody("FAILED: " + e.getMessage());

--- a/timeseries-lambda/src/test/java/com/leonarduk/aws/apigateway/ApiGatewayHandlerTest.java
+++ b/timeseries-lambda/src/test/java/com/leonarduk/aws/apigateway/ApiGatewayHandlerTest.java
@@ -1,0 +1,80 @@
+package com.leonarduk.aws.apigateway;
+
+import com.amazonaws.AmazonServiceException;
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
+import com.amazonaws.services.s3.AmazonS3;
+import com.leonarduk.aws.QueryRunner;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.util.Map;
+
+class ApiGatewayHandlerTest {
+
+    private ApiGatewayHandler buildHandler(AmazonS3 s3, QueryRunner runner, String bucket) throws Exception {
+        ApiGatewayHandler handler = new ApiGatewayHandler(s3, bucket);
+        if (runner != null) {
+            Field field = ApiGatewayHandler.class.getDeclaredField("queryRunner");
+            field.setAccessible(true);
+            field.set(handler, runner);
+        }
+        return handler;
+    }
+
+    @Test
+    void uploadsResultToS3() throws Exception {
+        AmazonS3 s3 = Mockito.mock(AmazonS3.class);
+        QueryRunner runner = Mockito.mock(QueryRunner.class);
+        Mockito.when(runner.getResults(Mockito.any())).thenReturn("HTML");
+
+        ApiGatewayHandler handler = buildHandler(s3, runner, "bucket");
+
+        APIGatewayProxyRequestEvent request = new APIGatewayProxyRequestEvent();
+        request.setQueryStringParameters(Map.of(QueryRunner.TICKER, "TEST"));
+
+        APIGatewayProxyResponseEvent response = handler.handleRequest(request, null);
+
+        Assertions.assertEquals(200, response.getStatusCode());
+        Mockito.verify(s3).putObject(Mockito.eq("bucket"), Mockito.eq("results/TEST.html"), Mockito.anyString());
+    }
+
+    @Test
+    void s3FailureReturnsBadGateway() throws Exception {
+        AmazonS3 s3 = Mockito.mock(AmazonS3.class);
+        Mockito.doThrow(new AmazonServiceException("fail"))
+                .when(s3).putObject(Mockito.anyString(), Mockito.anyString(), Mockito.anyString());
+        QueryRunner runner = Mockito.mock(QueryRunner.class);
+        Mockito.when(runner.getResults(Mockito.any())).thenReturn("HTML");
+
+        ApiGatewayHandler handler = buildHandler(s3, runner, "bucket");
+
+        APIGatewayProxyRequestEvent request = new APIGatewayProxyRequestEvent();
+        request.setQueryStringParameters(Map.of(QueryRunner.TICKER, "TEST"));
+
+        APIGatewayProxyResponseEvent response = handler.handleRequest(request, null);
+
+        Assertions.assertEquals(502, response.getStatusCode());
+    }
+
+    @Test
+    void queryRunnerFailureReturnsServerError() throws Exception {
+        AmazonS3 s3 = Mockito.mock(AmazonS3.class);
+        QueryRunner runner = Mockito.mock(QueryRunner.class);
+        Mockito.when(runner.getResults(Mockito.any())).thenThrow(new IOException("io"));
+
+        ApiGatewayHandler handler = buildHandler(s3, runner, "bucket");
+
+        APIGatewayProxyRequestEvent request = new APIGatewayProxyRequestEvent();
+        request.setQueryStringParameters(Map.of(QueryRunner.TICKER, "TEST"));
+
+        APIGatewayProxyResponseEvent response = handler.handleRequest(request, null);
+
+        Assertions.assertEquals(500, response.getStatusCode());
+        Mockito.verify(s3, Mockito.never())
+                .putObject(Mockito.anyString(), Mockito.anyString(), Mockito.anyString());
+    }
+}


### PR DESCRIPTION
## Summary
- initialize Amazon S3 client in API handler
- upload query results to S3 and return HTTP codes on failures
- add unit tests for S3 success and error scenarios

## Testing
- `mvn -q test` *(fails: Network is unreachable for Maven dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68a04867c70c83278052aa39849e008e