### PR TITLE
refactor: rename Data generic to Response in DigitalCurrencyParser

### DIFF
--- a/alphavantage4j/src/main/java/org/patriques/output/digitalcurrencies/DigitalCurrencyParser.java
+++ b/alphavantage4j/src/main/java/org/patriques/output/digitalcurrencies/DigitalCurrencyParser.java
@@ -9,16 +9,15 @@ import com.google.gson.reflect.TypeToken;
 import org.patriques.output.AlphaVantageException;
 import org.patriques.output.JsonParser;
 
-// TODO rename data to response
 /**
  * Since the format for the digital and crypto currency responses differ slightly but on the whole
  * have the same structure the {@code DigitalCurrencyParser} extracts the similarity of
  * the parsing to this class.
  *
  * @see JsonParser
- * @param <Data> the response for each individual Response, i.e Intraday, Daily etc.
+ * @param <Response> the response for each individual API call, i.e Intraday, Daily etc.
  */
-abstract class DigitalCurrencyParser<Data> extends JsonParser<Data> {
+abstract class DigitalCurrencyParser<Response> extends JsonParser<Response> {
 
   /**
    * The specifics of the resolution is pushed down to each response type, i.e Intraday, Daily etc.
@@ -27,8 +26,8 @@ abstract class DigitalCurrencyParser<Data> extends JsonParser<Data> {
    * @param digitalCurrencyData the digital currency data
    * @return the response for each individual response, i.e Intraday, Daily etc.
    */
-  abstract Data resolve(Map<String, String> metaData,
-                        Map<String, Map<String, String>> digitalCurrencyData) ;
+  abstract Response resolve(Map<String, String> metaData,
+                            Map<String, Map<String, String>> digitalCurrencyData) ;
 
   /**
    * Gets the key for the digital currency data, this differs for each response type, i.e Intraday, Daily etc.
@@ -39,14 +38,14 @@ abstract class DigitalCurrencyParser<Data> extends JsonParser<Data> {
   abstract String getDigitalCurrencyDataKey();
 
   @Override
-  public Data resolve(JsonObject rootObject)  {
+  public Response resolve(JsonObject rootObject)  {
     Type metaDataType = new TypeToken<Map<String, String>>() {
     }.getType();
-    Type dataType = new TypeToken<Map<String, Map<String, String>>>() {
+    Type responseType = new TypeToken<Map<String, Map<String, String>>>() {
     }.getType();
     try {
       Map<String, String> metaData = GSON.fromJson(rootObject.get("Meta Data"), metaDataType);
-      Map<String, Map<String, String>> digitalCurrencyData = GSON.fromJson(rootObject.get(getDigitalCurrencyDataKey()), dataType);
+      Map<String, Map<String, String>> digitalCurrencyData = GSON.fromJson(rootObject.get(getDigitalCurrencyDataKey()), responseType);
       return resolve(metaData, digitalCurrencyData);
     } catch (JsonSyntaxException e) {
       throw new AlphaVantageException("time series api change", e);


### PR DESCRIPTION
## Summary
- rename `Data` generic type to `Response` in `DigitalCurrencyParser`
- update variable names and documentation to match

## Testing
- `mvn test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:pom:3.3.1 - Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a048632f408327b308161840aec33b