### PR TITLE
Validate Moneyhub dividend stock names

### DIFF
--- a/timeseries-python/integrations/portfolioperformance/import/moneyhub/stock_name_map.py
+++ b/timeseries-python/integrations/portfolioperformance/import/moneyhub/stock_name_map.py
@@ -1,0 +1,6 @@
+"""Mapping of raw Moneyhub security names to Portfolio Performance names."""
+
+STOCK_NAME_MAP = {
+    # Example mapping used in tests. Real deployments can extend this file.
+    "AstraZeneca plc Ordinary US$0.25": "AstraZeneca PLC",
+}

--- a/timeseries-python/tests/test_transaction_converter_dividends.py
+++ b/timeseries-python/tests/test_transaction_converter_dividends.py
@@ -1,0 +1,66 @@
+import os
+import sys
+
+import pandas as pd
+import importlib
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+module = importlib.import_module(
+    "integrations.portfolioperformance.import.moneyhub.transaction_converter"
+)
+_convert_account_df = module._convert_account_df
+
+
+def _make_df(rows):
+    return pd.DataFrame(rows)
+
+
+def test_dividend_mapping_mapped():
+    df = _make_df(
+        {
+            "ACCOUNT": ["Steve SIPP"],
+            "CATEGORY": ["Savings & investments income"],
+            "DESCRIPTION": ["AstraZeneca plc Ordinary US$0.25 Dividend Payment"],
+            "DATE": ["2024-01-01"],
+            "AMOUNT": [10.0],
+        }
+    )
+    result = _convert_account_df(
+        df,
+        account="Steve SIPP",
+        currency="",
+        exclude_dividends=False,
+        cash_account_map={"Steve SIPP": "Steve SIPP Cash"},
+        offset_account_map={"Steve SIPP": "Steve SIPP Shares"},
+    )
+    assert result.iloc[0]["Security Name"] == "AstraZeneca PLC"
+    assert result.iloc[0]["Cash Account"] == "Steve SIPP Cash"
+    assert result.iloc[0]["Offset Account"] == "Steve SIPP Shares"
+
+
+def test_dividend_mapping_unmapped_dropped():
+    df = _make_df(
+        {
+            "ACCOUNT": ["Steve SIPP", "Steve SIPP"],
+            "CATEGORY": [
+                "Savings & investments income",
+                "Savings & investments income",
+            ],
+            "DESCRIPTION": [
+                "AstraZeneca plc Ordinary US$0.25 Dividend Payment",
+                "Unknown Corp Dividend Payment",
+            ],
+            "DATE": ["2024-01-01", "2024-02-01"],
+            "AMOUNT": [10.0, 5.0],
+        }
+    )
+    result = _convert_account_df(
+        df,
+        account="Steve SIPP",
+        currency="",
+        exclude_dividends=False,
+        cash_account_map={"Steve SIPP": "Steve SIPP Cash"},
+        offset_account_map={"Steve SIPP": "Steve SIPP Shares"},
+    )
+    # Only the mapped dividend should remain
+    assert list(result["Security Name"]) == ["AstraZeneca PLC"]


### PR DESCRIPTION
## Summary
- map Moneyhub dividend security names using `STOCK_NAME_MAP` and drop unknown entries
- add separate stock name mapping module
- cover mapped vs. unmapped dividend mapping with tests

## Testing
- `pre-commit run --files timeseries-python/integrations/portfolioperformance/import/moneyhub/transaction_converter.py timeseries-python/integrations/portfolioperformance/import/moneyhub/stock_name_map.py timeseries-python/tests/test_transaction_converter_dividends.py`
- `pytest timeseries-python/tests/test_transaction_converter_dividends.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a048624a6c8327b7b6ed5740be675e