### PR TITLE
Handle currency conversion in timeseries cleanup

### DIFF
--- a/timeseries-stockfeed/src/main/java/com/leonarduk/finance/utils/TimeseriesUtils.java
+++ b/timeseries-stockfeed/src/main/java/com/leonarduk/finance/utils/TimeseriesUtils.java
@@ -6,10 +6,13 @@ import com.leonarduk.finance.stockfeed.datatransformation.correction.BadScalingC
 import com.leonarduk.finance.stockfeed.datatransformation.correction.NullValueRemover;
 import com.leonarduk.finance.stockfeed.datatransformation.interpolation.FlatLineInterpolator;
 import com.leonarduk.finance.stockfeed.datatransformation.interpolation.LinearInterpolator;
+import com.leonarduk.finance.stockfeed.Instrument;
 import com.leonarduk.finance.stockfeed.feed.Commentable;
 import com.leonarduk.finance.stockfeed.feed.ExtendedHistoricalQuote;
 import com.leonarduk.finance.stockfeed.feed.yahoofinance.StockV1;
 import com.leonarduk.finance.stockfeed.file.FileBasedDataStore;
+import com.leonarduk.finance.utils.exchange.ExchangeRateService;
+import com.leonarduk.finance.utils.exchange.EnvironmentExchangeRateService;
 import org.ta4j.core.Bar;
 import org.ta4j.core.BarSeries;
 import org.ta4j.core.BaseBarSeriesBuilder;
@@ -24,22 +27,85 @@ import java.time.temporal.ChronoUnit;
 import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import java.time.ZoneId;
 
 public class TimeseriesUtils {
+
+    private static ExchangeRateService exchangeRateService = new EnvironmentExchangeRateService();
+
+    public static void setExchangeRateService(ExchangeRateService service) {
+        exchangeRateService = service;
+    }
+
     public static int cleanUpSeries(final Optional<StockV1> liveData) throws IOException {
         if (liveData.isPresent()) {
             final List<Bar> history = liveData.get().getHistory();
             final int original = history.size();
-            final List<Bar> clean = new BadScalingCorrector().clean(new BadDateRemover().clean(new NullValueRemover().clean(history)));
+            List<Bar> clean = new BadScalingCorrector().clean(new BadDateRemover().clean(new NullValueRemover().clean(history)));
 
-            // TODO scale to/from USD to GBP or GBX
+            Instrument instrument = liveData.get().getInstrument();
+            clean = convertCurrencyIfRequired(liveData.get().getCurrency(), instrument.getCurrency(), instrument, clean);
             liveData.get().setHistory(clean);
+            liveData.get().setCurrency(instrument.getCurrency());
 
             final int fixed = clean.size();
             return original - fixed;
         }
         return 0;
+    }
+
+    private static List<Bar> convertCurrencyIfRequired(String dataCurrency, String instrumentCurrency,
+                                                       Instrument instrument, List<Bar> bars) throws IOException {
+        if (dataCurrency == null || instrumentCurrency == null || dataCurrency.equalsIgnoreCase(instrumentCurrency)) {
+            return bars;
+        }
+        double rate = getConversionRate(dataCurrency, instrumentCurrency);
+        if (rate == 1d) {
+            return bars;
+        }
+        final double conversion = rate;
+        return bars.stream()
+                .map(b -> scaleBar(b, conversion, instrument))
+                .collect(Collectors.toList());
+    }
+
+    private static double getConversionRate(String fromCurrency, String toCurrency) throws IOException {
+        String from = fromCurrency.toUpperCase();
+        String to = toCurrency.toUpperCase();
+        if (from.equals(to)) {
+            return 1d;
+        }
+        if (from.equals("GBP") && to.equals("GBX")) {
+            return 100d;
+        }
+        if (from.equals("GBX") && to.equals("GBP")) {
+            return 0.01d;
+        }
+        if (from.equals("USD") && to.equals("GBP")) {
+            return exchangeRateService.getRate("USD", "GBP").doubleValue();
+        }
+        if (from.equals("USD") && to.equals("GBX")) {
+            return exchangeRateService.getRate("USD", "GBP").multiply(BigDecimal.valueOf(100d)).doubleValue();
+        }
+        if (from.equals("GBP") && to.equals("USD")) {
+            return exchangeRateService.getRate("GBP", "USD").doubleValue();
+        }
+        if (from.equals("GBX") && to.equals("USD")) {
+            return exchangeRateService.getRate("GBP", "USD").multiply(BigDecimal.valueOf(0.01d)).doubleValue();
+        }
+        return 1d;
+    }
+
+    private static Bar scaleBar(Bar bar, double rate, Instrument instrument) {
+        BigDecimal factor = BigDecimal.valueOf(rate);
+        BigDecimal open = BigDecimal.valueOf(bar.getOpenPrice().doubleValue()).multiply(factor);
+        BigDecimal high = BigDecimal.valueOf(bar.getHighPrice().doubleValue()).multiply(factor);
+        BigDecimal low = BigDecimal.valueOf(bar.getLowPrice().doubleValue()).multiply(factor);
+        BigDecimal close = BigDecimal.valueOf(bar.getClosePrice().doubleValue()).multiply(factor);
+        String comment = bar instanceof Commentable ? ((Commentable) bar).getComment() : "";
+        return new ExtendedHistoricalQuote(instrument,
+                bar.getEndTime().atZone(ZoneId.systemDefault()).toLocalDate(),
+                open, low, high, close, close,
+                bar.getVolume().longValue(), comment);
     }
 
     public static boolean containsDatePoints(final List<Bar> cachedHistory, final LocalDate... dates) {

--- a/timeseries-stockfeed/src/main/java/com/leonarduk/finance/utils/exchange/EnvironmentExchangeRateService.java
+++ b/timeseries-stockfeed/src/main/java/com/leonarduk/finance/utils/exchange/EnvironmentExchangeRateService.java
@@ -1,0 +1,31 @@
+package com.leonarduk.finance.utils.exchange;
+
+import java.io.IOException;
+import java.math.BigDecimal;
+
+/**
+ * Simple implementation of {@link ExchangeRateService} that retrieves rates
+ * from system properties or environment variables. The lookup key uses the
+ * format {@code FROM_TO_RATE}, e.g. {@code USD_GBP_RATE}.
+ * If no value is found a rate of {@link BigDecimal#ONE} is returned.
+ */
+public class EnvironmentExchangeRateService implements ExchangeRateService {
+
+    @Override
+    public BigDecimal getRate(String fromCurrency, String toCurrency) throws IOException {
+        String key = (fromCurrency + "_" + toCurrency + "_RATE").toUpperCase();
+        String value = System.getProperty(key);
+        if (value == null) {
+            value = System.getenv(key);
+        }
+        if (value == null) {
+            return BigDecimal.ONE;
+        }
+        try {
+            return new BigDecimal(value);
+        } catch (NumberFormatException e) {
+            throw new IOException("Invalid exchange rate for " + key, e);
+        }
+    }
+}
+

--- a/timeseries-stockfeed/src/main/java/com/leonarduk/finance/utils/exchange/ExchangeRateService.java
+++ b/timeseries-stockfeed/src/main/java/com/leonarduk/finance/utils/exchange/ExchangeRateService.java
@@ -1,0 +1,21 @@
+package com.leonarduk.finance.utils.exchange;
+
+import java.io.IOException;
+import java.math.BigDecimal;
+
+/**
+ * Service for obtaining foreign exchange rates.
+ */
+public interface ExchangeRateService {
+
+    /**
+     * Retrieve the conversion rate from one currency to another.
+     *
+     * @param fromCurrency the currency we are converting from
+     * @param toCurrency   the target currency
+     * @return the conversion rate
+     * @throws IOException if the rate could not be retrieved
+     */
+    BigDecimal getRate(String fromCurrency, String toCurrency) throws IOException;
+}
+

--- a/timeseries-stockfeed/src/test/java/com/leonarduk/finance/utils/TimeseriesUtilsTest.java
+++ b/timeseries-stockfeed/src/test/java/com/leonarduk/finance/utils/TimeseriesUtilsTest.java
@@ -3,6 +3,8 @@ package com.leonarduk.finance.utils;
 import com.google.common.collect.Lists;
 import com.leonarduk.finance.stockfeed.Instrument;
 import com.leonarduk.finance.stockfeed.feed.ExtendedHistoricalQuote;
+import com.leonarduk.finance.stockfeed.feed.yahoofinance.StockV1;
+import com.leonarduk.finance.utils.exchange.ExchangeRateService;
 import org.junit.Assert;
 import org.junit.Test;
 import org.ta4j.core.Bar;
@@ -10,6 +12,7 @@ import org.ta4j.core.Bar;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Optional;
 
 public class TimeseriesUtilsTest {
 
@@ -68,6 +71,44 @@ public class TimeseriesUtilsTest {
                 BigDecimal.valueOf(9.3), BigDecimal.valueOf(12.2), BigDecimal.valueOf(12.2), 23L, "TestCache"));
 
         Assert.assertEquals(0, TimeseriesUtils.getMissingDataPoints(cachedHistory, fromDate, toDate).size());
+    }
+
+    @Test
+    public void testCleanUpSeriesUsdToGbpConversion() throws Exception {
+        Instrument instrument = Instrument.fromString("TEST1", "L", "EQUITY", "GBP");
+        List<Bar> history = Lists.newArrayList();
+        history.add(new ExtendedHistoricalQuote(instrument, LocalDate.parse("2020-01-01"),
+                BigDecimal.ONE, BigDecimal.ONE, BigDecimal.ONE,
+                BigDecimal.ONE, BigDecimal.ONE, 1L, ""));
+        StockV1 stock = new StockV1(instrument, history);
+        stock.setCurrency("USD");
+
+        ExchangeRateService service = (from, to) -> BigDecimal.valueOf(0.8);
+        TimeseriesUtils.setExchangeRateService(service);
+
+        TimeseriesUtils.cleanUpSeries(Optional.of(stock));
+        Bar converted = stock.getHistory().get(0);
+        Assert.assertEquals(0.8, converted.getClosePrice().doubleValue(), 0.0001);
+        Assert.assertEquals("GBP", stock.getCurrency());
+    }
+
+    @Test
+    public void testCleanUpSeriesUsdToGbxConversion() throws Exception {
+        Instrument instrument = Instrument.fromString("TEST2", "L", "EQUITY", "GBX");
+        List<Bar> history = Lists.newArrayList();
+        history.add(new ExtendedHistoricalQuote(instrument, LocalDate.parse("2020-01-01"),
+                BigDecimal.ONE, BigDecimal.ONE, BigDecimal.ONE,
+                BigDecimal.ONE, BigDecimal.ONE, 1L, ""));
+        StockV1 stock = new StockV1(instrument, history);
+        stock.setCurrency("USD");
+
+        ExchangeRateService service = (from, to) -> BigDecimal.valueOf(0.8);
+        TimeseriesUtils.setExchangeRateService(service);
+
+        TimeseriesUtils.cleanUpSeries(Optional.of(stock));
+        Bar converted = stock.getHistory().get(0);
+        Assert.assertEquals(80.0, converted.getClosePrice().doubleValue(), 0.0001);
+        Assert.assertEquals("GBX", stock.getCurrency());
     }
 
 }


### PR DESCRIPTION
## Summary
- convert bars between USD and GBP/GBX using exchange rates
- add environment-based exchange rate service
- cover currency conversions in TimeseriesUtils tests

## Testing
- `mvn -q test` *(fails: Could not transfer artifact: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a04860e8248327aa45e05a433e9f1a