### PR TITLE
Escape commas in CSV comments

### DIFF
--- a/timeseries-stockfeed/src/main/java/com/leonarduk/finance/utils/StringUtils.java
+++ b/timeseries-stockfeed/src/main/java/com/leonarduk/finance/utils/StringUtils.java
@@ -23,11 +23,20 @@ public class StringUtils {
     }
 
     public static void addValue(final StringBuilder buf, final long value) {
-        buf.append(',').append(value);
+        StringUtils.addValue(buf, String.valueOf(value));
     }
 
     public static void addValue(final StringBuilder buf, final String value) {
-        buf.append(',').append(value);
+        buf.append(',');
+        if (value == null) {
+            return;
+        }
+        String escaped = value.replace("\"", "\"\"");
+        if (value.contains(",") || value.contains("\"") || value.contains("\n") || value.contains("\r")) {
+            buf.append('"').append(escaped).append('"');
+        } else {
+            buf.append(escaped);
+        }
     }
 
     public static String getString(final String data) {

--- a/timeseries-stockfeed/src/main/java/com/leonarduk/finance/utils/TimeseriesUtils.java
+++ b/timeseries-stockfeed/src/main/java/com/leonarduk/finance/utils/TimeseriesUtils.java
@@ -156,7 +156,7 @@ public class TimeseriesUtils {
             StringUtils.addValue(sb, historicalQuote.getClosePrice());
             StringUtils.addValue(sb, historicalQuote.getVolume());
             if (historicalQuote instanceof Commentable commentable) {
-                sb.append(",").append(commentable.getComment());
+                StringUtils.addValue(sb, commentable.getComment());
             }
             sb.append("\n");
         }

--- a/timeseries-stockfeed/src/test/java/com/leonarduk/finance/utils/TimeseriesUtilsTest.java
+++ b/timeseries-stockfeed/src/test/java/com/leonarduk/finance/utils/TimeseriesUtilsTest.java
@@ -50,6 +50,19 @@ public class TimeseriesUtilsTest {
     }
 
     @Test
+    public void testSeriesToCsvEscapesCommaInComment() {
+        final List<Bar> series = Lists.newArrayList();
+        series.add(new ExtendedHistoricalQuote(Instrument.CASH, LocalDate.parse("2017-01-01"), BigDecimal.valueOf(12.3),
+                BigDecimal.TEN, BigDecimal.valueOf(9.3), BigDecimal.valueOf(12.2), BigDecimal.valueOf(12.2), 23L,
+                "Comment, with comma"));
+        final StringBuilder actual = TimeseriesUtils.seriesToCsv(series);
+        Assert.assertEquals(
+                "date,open,high,low,close,volume,comment\n" +
+                        "2017-01-01,12.30,9.30,10.00,12.20,23.00,\"Comment, with comma\"\n",
+                actual.toString());
+    }
+
+    @Test
     public void testGetMissingDataPoints() throws Exception {
         final LocalDate toDate = LocalDate.parse("2017-01-03");
         final LocalDate fromDate = LocalDate.parse("2017-01-01");


### PR DESCRIPTION
## Summary
- Use `StringUtils.addValue` for comment fields in `TimeseriesUtils.seriesToCsv` and enhance `StringUtils` to escape commas, quotes, and newlines.
- Add test ensuring comments containing commas serialize with proper CSV quoting.

## Testing
- `mvn -q test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 or one of its dependencies could not be resolved: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a0485bbbcc8327852a423763b3612b