### PR TITLE
Handle zero baseline in series alignment

### DIFF
--- a/timeseries-spring-boot-server/src/main/java/com/leonarduk/finance/springboot/SeriesEndpoint.java
+++ b/timeseries-spring-boot-server/src/main/java/com/leonarduk/finance/springboot/SeriesEndpoint.java
@@ -3,6 +3,8 @@ package com.leonarduk.finance.springboot;
 import com.leonarduk.finance.stockfeed.Instrument;
 import com.leonarduk.finance.stockfeed.StockFeed;
 import com.leonarduk.finance.stockfeed.feed.yahoofinance.StockV1;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.*;
 import org.ta4j.core.Bar;
@@ -19,6 +21,8 @@ import java.util.stream.Collectors;
 @RequestMapping("/series")
 @RestController
 public class SeriesEndpoint {
+
+    private static final Logger log = LoggerFactory.getLogger(SeriesEndpoint.class);
 
     @Autowired
     private final StockFeed stockFeed;
@@ -80,7 +84,12 @@ public class SeriesEndpoint {
             return Collections.emptyMap();
         }
         LocalDate start = intersection.first();
-        double scale = target.get(start) / source.get(start);
+        double sourceStart = source.get(start);
+        if (sourceStart == 0.0) {
+            log.warn("Source baseline value is zero for date {}", start);
+            return Collections.emptyMap();
+        }
+        double scale = target.get(start) / sourceStart;
 
         Map<LocalDate, Double> rebased = source.entrySet().stream()
                 .collect(Collectors.toMap(Map.Entry::getKey, e -> e.getValue() * scale));

--- a/timeseries-spring-boot-server/src/test/java/com/leonarduk/finance/springboot/SeriesEndpointTest.java
+++ b/timeseries-spring-boot-server/src/test/java/com/leonarduk/finance/springboot/SeriesEndpointTest.java
@@ -98,4 +98,29 @@ class SeriesEndpointTest {
                 .andExpect(jsonPath("$.mapped['2023-01-03']").value(55.0))
                 .andExpect(jsonPath("$.mapped['2023-01-04']").value(60.0));
     }
+
+    @Test
+    void mapSeriesReturnsEmptyWhenSourceBaselineZero() throws Exception {
+        List<Bar> srcQuotes = Arrays.asList(
+                new ExtendedHistoricalQuote(Instrument.CASH, LocalDate.parse("2023-01-01"), 0, 0, 0, 0, 0, 0, ""),
+                new ExtendedHistoricalQuote(Instrument.CASH, LocalDate.parse("2023-01-02"), 10, 10, 10, 10, 10, 0, "")
+        );
+        List<Bar> tgtQuotes = Arrays.asList(
+                new ExtendedHistoricalQuote(Instrument.UNKNOWN, LocalDate.parse("2023-01-01"), 50, 50, 50, 50, 50, 0, ""),
+                new ExtendedHistoricalQuote(Instrument.UNKNOWN, LocalDate.parse("2023-01-02"), 55, 55, 55, 55, 55, 0, "")
+        );
+        StockV1 srcStock = AbstractStockFeed.createStock(Instrument.CASH, srcQuotes);
+        StockV1 tgtStock = AbstractStockFeed.createStock(Instrument.UNKNOWN, tgtQuotes);
+
+        Mockito.when(stockFeed.get(argThat(i -> i != null && "CASH".equalsIgnoreCase(i.getCode())), anyInt(), anyBoolean(), anyBoolean(), anyBoolean()))
+                .thenReturn(Optional.of(srcStock));
+        Mockito.when(stockFeed.get(argThat(i -> i != null && "UNKNOWN".equalsIgnoreCase(i.getCode())), anyInt(), anyBoolean(), anyBoolean(), anyBoolean()))
+                .thenReturn(Optional.of(tgtStock));
+
+        mockMvc.perform(post("/series/map")
+                        .param("source", "CASH")
+                        .param("target", "UNKNOWN"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.mapped").isEmpty());
+    }
 }


### PR DESCRIPTION
## Summary
- avoid division by zero when aligning time series by warning and returning empty map if baseline is zero
- cover zero-baseline alignment with unit test

## Testing
- `pre-commit run --files timeseries-spring-boot-server/src/main/java/com/leonarduk/finance/springboot/SeriesEndpoint.java timeseries-spring-boot-server/src/test/java/com/leonarduk/finance/springboot/SeriesEndpointTest.java`
- `mvn -q -pl timeseries-spring-boot-server -am test` *(fails: Non-resolvable parent POM; Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a0d7fcd6188327a0fd32b7623d0d74