### PR TITLE
Inject MessageSource via constructor in RiskEndpoint

### DIFF
--- a/timeseries-spring-boot-server/src/main/java/com/leonarduk/finance/springboot/RiskEndpoint.java
+++ b/timeseries-spring-boot-server/src/main/java/com/leonarduk/finance/springboot/RiskEndpoint.java
@@ -1,7 +1,6 @@
 package com.leonarduk.finance.springboot;
 
 import org.apache.commons.lang3.StringUtils;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.MessageSource;
 import org.springframework.context.i18n.LocaleContextHolder;
 import org.springframework.http.HttpStatus;
@@ -21,8 +20,11 @@ import java.util.Map;
 @RequestMapping("/risk")
 public class RiskEndpoint {
 
-    @Autowired
-    private MessageSource messageSource;
+    private final MessageSource messageSource;
+
+    public RiskEndpoint(MessageSource messageSource) {
+        this.messageSource = messageSource;
+    }
 
     /**
      * Calculate historical simulation Value at Risk (VaR) for a series of returns.

--- a/timeseries-spring-boot-server/src/test/java/com/leonarduk/finance/springboot/RiskEndpointTest.java
+++ b/timeseries-spring-boot-server/src/test/java/com/leonarduk/finance/springboot/RiskEndpointTest.java
@@ -1,0 +1,56 @@
+package com.leonarduk.finance.springboot;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.context.MessageSource;
+import org.springframework.web.server.ResponseStatusException;
+
+class RiskEndpointTest {
+
+    @Test
+    void usesLangParameterForLocaleSpecificMessage() {
+        MessageSource messageSource = mock(MessageSource.class);
+        when(messageSource.getMessage(eq("returns.empty"), isNull(), eq(Locale.FRENCH)))
+                .thenReturn("Aucune donnée de rendement fournie");
+
+        RiskEndpoint endpoint = new RiskEndpoint(messageSource);
+
+        Map<String, List<Double>> body = Map.of("returns", Collections.emptyList());
+
+        ResponseStatusException ex =
+                assertThrows(
+                        ResponseStatusException.class,
+                        () -> endpoint.historicVar(body, 0.95, null, "fr"));
+
+        assertEquals("Aucune donnée de rendement fournie", ex.getReason());
+    }
+
+    @Test
+    void usesAcceptLanguageHeaderForLocaleSpecificMessage() {
+        MessageSource messageSource = mock(MessageSource.class);
+        when(messageSource.getMessage(eq("returns.empty"), isNull(), eq(Locale.GERMAN)))
+                .thenReturn("Keine Renditedaten");
+
+        RiskEndpoint endpoint = new RiskEndpoint(messageSource);
+
+        Map<String, List<Double>> body = Map.of("returns", Collections.emptyList());
+
+        ResponseStatusException ex =
+                assertThrows(
+                        ResponseStatusException.class,
+                        () -> endpoint.historicVar(body, 0.95, "de", null));
+
+        assertEquals("Keine Renditedaten", ex.getReason());
+    }
+}


### PR DESCRIPTION
## Summary
- switch `RiskEndpoint` to constructor injection for `MessageSource`
- add unit tests verifying locale-specific error messages

## Testing
- `mvn -pl timeseries-spring-boot-server -am test` *(fails: Non-resolvable parent POM for org.springframework.boot:spring-boot-starter-parent: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a0d7fbf5ac8327a718a167e31cd785