### PR TITLE
Use Lombok logger in SeriesEndpoint

### DIFF
--- a/timeseries-spring-boot-server/src/main/java/com/leonarduk/finance/springboot/SeriesEndpoint.java
+++ b/timeseries-spring-boot-server/src/main/java/com/leonarduk/finance/springboot/SeriesEndpoint.java
@@ -3,8 +3,7 @@ package com.leonarduk.finance.springboot;
 import com.leonarduk.finance.stockfeed.Instrument;
 import com.leonarduk.finance.stockfeed.StockFeed;
 import com.leonarduk.finance.stockfeed.feed.yahoofinance.StockV1;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.*;
 import org.ta4j.core.Bar;
@@ -18,11 +17,10 @@ import java.util.stream.Collectors;
 /**
  * REST endpoint exposing time-series utilities.
  */
+@Slf4j
 @RequestMapping("/series")
 @RestController
 public class SeriesEndpoint {
-
-    private static final Logger log = LoggerFactory.getLogger(SeriesEndpoint.class);
 
     @Autowired
     private final StockFeed stockFeed;


### PR DESCRIPTION
## Summary
- Replace manual logger setup in SeriesEndpoint with Lombok's @Slf4j annotation.
- Remove explicit Logger field and related imports.

## Testing
- `mvn -q -pl timeseries-spring-boot-server -am test` *(fails: Non-resolvable parent POM; network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a0ebf997e48327a9e1dacd1e6cbd34