### PR TITLE
chore: upgrade spring boot to 3.3.13

### DIFF
--- a/timeseries-spring-boot-server/pom.xml
+++ b/timeseries-spring-boot-server/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.2.5</version>
+        <version>3.3.13</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
 


### PR DESCRIPTION
## Summary
- upgrade timeseries-spring-boot-server parent to Spring Boot 3.3.13

## Testing
- `pre-commit run --files timeseries-spring-boot-server/pom.xml`
- `MAVEN_OPTS="-Djava.net.preferIPv4Stack=true -Djava.net.preferIPv6Addresses=false" mvn -pl timeseries-spring-boot-server -am clean package` *(fails: Network is unreachable when resolving parent POM)*
- `java -jar timeseries-spring-boot-server/target/timeseries-spring-boot-server-0.1.1.jar` *(fails: Unable to access jarfile)*

------
https://chatgpt.com/codex/tasks/task_e_68a0f9d2b128832784950c560e871eb8