### PR TITLE
test: ensure server starts with full Spring context

### DIFF
--- a/timeseries-spring-boot-server/src/test/java/com/leonarduk/finance/springboot/ApplicationStartupTest.java
+++ b/timeseries-spring-boot-server/src/test/java/com/leonarduk/finance/springboot/ApplicationStartupTest.java
@@ -1,0 +1,12 @@
+package com.leonarduk.finance.springboot;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class ApplicationStartupTest {
+
+    @Test
+    void contextLoads() {
+    }
+}


### PR DESCRIPTION
## Summary
- add ApplicationStartupTest to verify the Spring Boot server loads successfully

## Testing
- `mvn -pl timeseries-spring-boot-server test` *(fails: Non-resolvable parent POM, network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a10760a0208327b2ca550e72351d1c