### PR TITLE
chore: bump Spring Boot parent

### DIFF
--- a/timeseries-spring-boot-server/pom.xml
+++ b/timeseries-spring-boot-server/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.3.13</version>
+        <version>3.4.1</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
 


### PR DESCRIPTION
## Summary
- upgrade spring-boot-starter-parent to 3.4.1 so Spring Framework 6.2 features are available

## Testing
- `pre-commit run --files timeseries-spring-boot-server/pom.xml`
- `mvn -pl timeseries-spring-boot-server -am clean package` *(fails: Non-resolvable parent POM ... Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a0ff65bd8c832792ba068d0dc700fb