### PR TITLE
chore: add enforcer rules dependency

### DIFF
--- a/timeseries-spring-boot-server/pom.xml
+++ b/timeseries-spring-boot-server/pom.xml
@@ -174,6 +174,13 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-enforcer-plugin</artifactId>
                 <version>3.5.0</version>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.apache.maven.enforcer</groupId>
+                        <artifactId>enforcer-rules</artifactId>
+                        <version>3.5.0</version>
+                    </dependency>
+                </dependencies>
                 <executions>
                     <execution>
                         <id>enforce</id>


### PR DESCRIPTION
## Summary
- add enforcer-rules dependency to maven-enforcer-plugin

## Testing
- `pre-commit run --files timeseries-spring-boot-server/pom.xml`
- `mvn -q clean install` *(fails: Non-resolvable parent POM due to network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a1a40303648327a11dd21e6260149d