### PR TITLE
refactor: use coroutines for stock requests

### DIFF
--- a/android-app/app/build.gradle
+++ b/android-app/app/build.gradle
@@ -44,6 +44,9 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib:1.9.0"
     implementation 'com.squareup.retrofit2:retrofit:2.9.0'
     implementation 'com.squareup.retrofit2:converter-gson:2.9.0'
+    implementation 'androidx.lifecycle:lifecycle-viewmodel-ktx:2.6.2'
+    implementation 'androidx.lifecycle:lifecycle-livedata-ktx:2.6.2'
+    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3'
     testImplementation 'junit:junit:4.13.2'
     testImplementation 'com.squareup.okhttp3:mockwebserver:4.10.0'
     androidTestImplementation 'androidx.test.ext:junit:1.1.5'

--- a/android-app/app/src/main/java/com/example/stockapp/StockViewModel.kt
+++ b/android-app/app/src/main/java/com/example/stockapp/StockViewModel.kt
@@ -1,0 +1,44 @@
+package com.example.stockapp
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.example.stockapp.api.RetrofitClient
+import com.example.stockapp.api.StockService
+import kotlinx.coroutines.launch
+
+class StockViewModel : ViewModel() {
+    private val service: StockService = RetrofitClient.instance.create(StockService::class.java)
+
+    private val _items = MutableLiveData<List<String>>()
+    val items: LiveData<List<String>> = _items
+
+    private val _error = MutableLiveData<String?>()
+    val error: LiveData<String?> = _error
+
+    fun loadData() {
+        viewModelScope.launch {
+            try {
+                val tickers = service.listTickers()
+                val results = mutableListOf<String>()
+                for (ticker in tickers) {
+                    try {
+                        val price = service.getPrice(ticker)
+                        results.add("$ticker: $price")
+                    } catch (e: Exception) {
+                        results.add("$ticker: error")
+                    }
+                }
+                _items.value = results
+                _error.value = null
+            } catch (e: Exception) {
+                _error.value = "Failed to load tickers. Please try again."
+            }
+        }
+    }
+
+    fun retry() {
+        loadData()
+    }
+}

--- a/android-app/app/src/main/java/com/example/stockapp/api/StockService.kt
+++ b/android-app/app/src/main/java/com/example/stockapp/api/StockService.kt
@@ -1,13 +1,12 @@
 package com.example.stockapp.api
 
-import retrofit2.Call
 import retrofit2.http.GET
 import retrofit2.http.Path
 
 interface StockService {
     @GET("stock")
-    fun listTickers(): Call<List<String>>
+    suspend fun listTickers(): List<String>
 
     @GET("price/{ticker}")
-    fun getPrice(@Path("ticker") ticker: String): Call<Double>
+    suspend fun getPrice(@Path("ticker") ticker: String): Double
 }

--- a/android-app/app/src/main/res/layout/activity_main.xml
+++ b/android-app/app/src/main/res/layout/activity_main.xml
@@ -4,8 +4,15 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
+    <Button
+        android:id="@+id/retryButton"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="Retry" />
+
     <ListView
         android:id="@+id/listView"
         android:layout_width="match_parent"
-        android:layout_height="match_parent" />
+        android:layout_height="0dp"
+        android:layout_weight="1" />
 </LinearLayout>


### PR DESCRIPTION
## Summary
- replace Retrofit callbacks with suspend functions
- drive stock loading from a ViewModel using coroutines
- surface results and errors through LiveData with a retry button

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a1a53592348327827a9a4d1599aec9