### PR TITLE
feat: centralize historical data handling

### DIFF
--- a/timeseries-lambda/src/main/java/com/leonarduk/aws/QueryRunner.java
+++ b/timeseries-lambda/src/main/java/com/leonarduk/aws/QueryRunner.java
@@ -1,191 +1,55 @@
 package com.leonarduk.aws;
 
-import com.leonarduk.finance.stockfeed.Instrument;
 import com.leonarduk.finance.stockfeed.StockFeed;
-import com.leonarduk.finance.stockfeed.feed.Commentable;
-import com.leonarduk.finance.stockfeed.feed.yahoofinance.StockV1;
+import com.leonarduk.finance.stockfeed.HistoricalDataService;
 import com.leonarduk.finance.utils.DataField;
 import com.leonarduk.finance.utils.HtmlTools;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.lang3.StringUtils;
-import org.ta4j.core.Bar;
 
 import java.io.IOException;
-import java.time.LocalDate;
-import java.time.ZoneId;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 
+/**
+ * Helper class used by AWS components to retrieve historical data and render it as
+ * HTML. Parameter parsing and record generation are delegated to
+ * {@link HistoricalDataService}.
+ */
 @Slf4j
 public class QueryRunner {
     public static final String INTERPOLATE = "interpolate";
     public static final String CLEAN_DATA = "cleanData";
     public static final String YEARS = "years";
     public static final String TICKER = "ticker";
+
     private final StockFeed stockFeed;
+    private final HistoricalDataService historicalDataService;
 
     public QueryRunner() {
-        stockFeed = DependencyFactory.stockFeed();
+        this(DependencyFactory.stockFeed());
+    }
 
+    public QueryRunner(StockFeed stockFeed) {
+        this.stockFeed = stockFeed;
+        this.historicalDataService = new HistoricalDataService(stockFeed);
     }
 
     /**
-     * Run this class as a command line application to test the functionality
-     * of this class.
-     * <p>
-     * This method is not intended to be called from outside this class.
-     * @param args command line args, not used
-     * @throws IOException if an IO error occurs
-     */
-    public static void main(final String[] args) throws IOException {
-        QueryRunner.log.info(new QueryRunner().getResults(Map.of(
-                QueryRunner.TICKER, "PHGP.L",
-                QueryRunner.YEARS, "1",
-                "interpolate", "true",
-                QueryRunner.CLEAN_DATA, "true"
-        )));
-    }
-
-    /**
-     * Retrieves results for a given financial instrument based on the input parameters.
+     * Retrieves results for a given set of parameters.
      *
-     * @param inputParams a map containing the parameters such as ticker, years, months, weeks, days,
-     *                    fromDate, toDate, interpolate, cleanData, region, type, and currency.
-     *                    <strong>The map must include the {@code ticker} key.</strong>
-     * @return a String representing the generated results in HTML format.
-     * @throws IOException if an IO error occurs during the retrieval of results.
-     * @throws IllegalArgumentException if the {@code inputParams} map is {@code null} or missing the required
-     *                                  {@code ticker} key.
+     * @param inputParams map of parameters – must include {@code ticker}
+     * @return HTML representation of the historical data
+     * @throws IOException if the underlying feed cannot be accessed
      */
     public String getResults(final Map<String, String> inputParams) throws IOException {
-
-        if (null == inputParams)
-        {
+        if (inputParams == null) {
             throw new IllegalArgumentException("No parameters provided. Expect at least ticker");
         }
-        QueryRunner.log.debug("Input parameters: {}", inputParams);
+        log.debug("Input parameters: {}", inputParams);
 
-        if (!inputParams.containsKey(QueryRunner.TICKER) || StringUtils.isBlank(inputParams.get(QueryRunner.TICKER))) {
-            throw new IllegalArgumentException("Ticker parameter is required");
-        }
-
-
-        String ticker = inputParams.get(QueryRunner.TICKER);
-
-        int years = Integer.parseInt(StringUtils.defaultIfEmpty(inputParams.get(QueryRunner.YEARS), "10"));
-        int months = Integer.parseInt(StringUtils.defaultIfEmpty(inputParams.get("months"), "0"));
-        int weeks = Integer.parseInt(StringUtils.defaultIfEmpty(inputParams.get("weeks"), "0"));
-        int days = Integer.parseInt(StringUtils.defaultIfEmpty(inputParams.get("days"), "0"));
-
-        String fromDate = inputParams.get("fromDate");
-        String toDate = inputParams.get("toDate");
-        boolean interpolate = Boolean.parseBoolean(StringUtils.defaultIfEmpty(inputParams.get(QueryRunner.INTERPOLATE), "False"));
-        boolean cleanData = Boolean.parseBoolean(StringUtils.defaultIfEmpty(inputParams.get(QueryRunner.CLEAN_DATA), "False"));
-
-        String region = StringUtils.defaultIfEmpty(inputParams.get("region"), "L");
-        String type = StringUtils.defaultIfEmpty(inputParams.get("type"), "UNKNOWN");
-        String currency = inputParams.get("currency");
-
-        if (ticker.contains(".")) {
-            final String[] parts = ticker.split("\\.");
-            ticker = parts[0];
-            region = parts[1];
-            if ("N".equalsIgnoreCase(region)) {
-                region = "NY";
-            }
-        }
-
-        if (ticker.contains("/")) {
-            final String[] parts = ticker.split("/");
-            ticker = parts[0];
-            region = parts[1];
-
-            if (2 < parts.length) {
-                type = parts[2];
-            }
-            if (3 < parts.length) {
-                currency = parts[3];
-            }
-        }
-
-        if (StringUtils.isBlank(currency)) {
-            currency = Instrument.resolveCurrency(inputParams.get(QueryRunner.TICKER));
-        }
-        Map<String, String> regionCurrencyMap = Map.of("NY", "USD", "L", "GBP");
-        if ((StringUtils.isBlank(currency) || "UNKNOWN".equalsIgnoreCase(currency))
-                && regionCurrencyMap.containsKey(region.toUpperCase())) {
-            currency = regionCurrencyMap.get(region.toUpperCase());
-        }
-        Instrument instrument = Instrument.fromString(ticker, region, type, currency);
-
-        final LocalDate toLocalDate;
-        LocalDate fromLocalDate;
-
-        if (!StringUtils.isEmpty(fromDate)) {
-            fromLocalDate = LocalDate.parse(fromDate);
-            if (StringUtils.isEmpty(toDate)) {
-                toLocalDate = LocalDate.now();
-            } else {
-                toLocalDate = LocalDate.parse(toDate);
-            }
-        } else {
-            toLocalDate = LocalDate.now();
-            if (0 < days) {
-                fromLocalDate = LocalDate.now().plusDays(-1 * days);
-            } else if (0 < weeks) {
-                fromLocalDate = LocalDate.now().plusWeeks(-1 * weeks);
-            } else if (0 < months) {
-                fromLocalDate = LocalDate.now().plusMonths(-1 * months);
-            } else {
-                fromLocalDate = LocalDate.now().plusYears(-1 * years);
-            }
-        }
-
-
-        return this.generateResults(fromLocalDate, toLocalDate, interpolate, cleanData, instrument);
-    }
-
-    private String generateResults(LocalDate fromLocalDate, LocalDate toLocalDate,
-                                   boolean interpolate, boolean cleanData,
-                                   Instrument instrument)
-            throws IOException {
+        List<List<DataField>> records = historicalDataService.getRecords(inputParams);
         StringBuilder sbBody = new StringBuilder();
-        List<List<DataField>> records = new ArrayList<>();
-
-        List<Bar> historyData;
-
-        historyData = getHistoryData(instrument, fromLocalDate, toLocalDate, interpolate, cleanData, false);
-
-        for (Bar historicalQuote : historyData) {
-            ArrayList<DataField> record = new ArrayList<>();
-            records.add(record);
-            record.add(new DataField("Date", historicalQuote.getEndTime().atZone(ZoneId.systemDefault()).toLocalDate().toString()));
-            record.add(new DataField("Open", historicalQuote.getOpenPrice()));
-            record.add(new DataField("High", historicalQuote.getHighPrice()));
-            record.add(new DataField("Low", historicalQuote.getLowPrice()));
-            record.add(new DataField("Close", historicalQuote.getClosePrice()));
-            record.add(new DataField("Volume", historicalQuote.getVolume()));
-
-            if (historicalQuote instanceof final Commentable commentable) {
-                record.add(new DataField("Comment", commentable.getComment()));
-
-            }
-        }
-
         HtmlTools.printTable(sbBody, records);
         return HtmlTools.createHtmlText(null, sbBody).toString();
     }
-
-    private List<Bar> getHistoryData(final Instrument instrument, final LocalDate fromLocalDate, final LocalDate toLocalDate,
-                                     final boolean interpolate, final boolean cleanData, final boolean addLatestQuoteToTheSeries) throws IOException {
-        Optional<StockV1> stock = stockFeed.get(instrument, fromLocalDate, toLocalDate, interpolate,
-                cleanData, addLatestQuoteToTheSeries);
-        if (stock.isPresent()) {
-            return stock.get().getHistory();
-        }
-        return new ArrayList<>();
-    }
-
 }

--- a/timeseries-lambda/src/test/java/com/leonarduk/aws/QueryRunnerTest.java
+++ b/timeseries-lambda/src/test/java/com/leonarduk/aws/QueryRunnerTest.java
@@ -6,7 +6,6 @@ import com.leonarduk.finance.stockfeed.feed.yahoofinance.StockV1;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-import java.lang.reflect.Field;
 import java.time.LocalDate;
 import java.util.Map;
 import java.util.Optional;
@@ -53,11 +52,8 @@ class QueryRunnerTest {
 
     @Test
     void providedCurrencyParameterIsRespected() throws Exception {
-        QueryRunner runner = new QueryRunner();
         RecordingStockFeed feed = new RecordingStockFeed();
-        Field field = QueryRunner.class.getDeclaredField("stockFeed");
-        field.setAccessible(true);
-        field.set(runner, feed);
+        QueryRunner runner = new QueryRunner(feed);
 
         Map<String, String> params = Map.of(
                 QueryRunner.TICKER, "TEST",
@@ -72,11 +68,8 @@ class QueryRunnerTest {
 
     @Test
     void currencyAutomaticallyResolved() throws Exception {
-        QueryRunner runner = new QueryRunner();
         RecordingStockFeed feed = new RecordingStockFeed();
-        Field field = QueryRunner.class.getDeclaredField("stockFeed");
-        field.setAccessible(true);
-        field.set(runner, feed);
+        QueryRunner runner = new QueryRunner(feed);
 
         Map<String, String> params = Map.of(
                 QueryRunner.TICKER, "BBAI.N"

--- a/timeseries-stockfeed/src/main/java/com/leonarduk/finance/stockfeed/HistoricalDataService.java
+++ b/timeseries-stockfeed/src/main/java/com/leonarduk/finance/stockfeed/HistoricalDataService.java
@@ -1,0 +1,166 @@
+package com.leonarduk.finance.stockfeed;
+
+import com.leonarduk.finance.stockfeed.datatransformation.correction.ValueScalingTransformer;
+import com.leonarduk.finance.stockfeed.feed.Commentable;
+import com.leonarduk.finance.stockfeed.feed.yahoofinance.StockV1;
+import com.leonarduk.finance.utils.DataField;
+import org.apache.commons.lang3.StringUtils;
+import org.ta4j.core.Bar;
+
+import java.io.IOException;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.*;
+
+/**
+ * Service for retrieving and formatting historical data from a {@link StockFeed}.
+ * This centralises the parameter parsing and record generation used by
+ * different entry points (lambda and REST).
+ */
+public class HistoricalDataService {
+    private final StockFeed stockFeed;
+
+    public HistoricalDataService(StockFeed stockFeed) {
+        this.stockFeed = stockFeed;
+    }
+
+    /**
+     * Fetch historical data based on the supplied parameters.
+     * <p>
+     * Expected parameters include:
+     * <ul>
+     *   <li>ticker (required)</li>
+     *   <li>years/months/weeks/days or fromDate/toDate</li>
+     *   <li>interpolate, cleanData</li>
+     *   <li>region, type, currency</li>
+     *   <li>scaling, category</li>
+     * </ul>
+     *
+     * @param params request parameters
+     * @return list of {@link DataField} records
+     * @throws IOException when the underlying feed cannot be accessed
+     */
+    public List<List<DataField>> getRecords(Map<String, String> params) throws IOException {
+        if (params == null || !params.containsKey("ticker") || StringUtils.isBlank(params.get("ticker"))) {
+            throw new IllegalArgumentException("Ticker parameter is required");
+        }
+
+        String ticker = params.get("ticker");
+        String region = StringUtils.defaultIfEmpty(params.get("region"), "L");
+        String type = StringUtils.defaultIfEmpty(params.get("type"), "UNKNOWN");
+        String currency = params.get("currency");
+
+        if (ticker.contains(".")) {
+            String[] parts = ticker.split("\\.");
+            ticker = parts[0];
+            region = parts[1];
+            if ("N".equalsIgnoreCase(region)) {
+                region = "NY";
+            }
+        }
+
+        if (ticker.contains("/")) {
+            String[] parts = ticker.split("/");
+            ticker = parts[0];
+            region = parts[1];
+            if (parts.length > 2) {
+                type = parts[2];
+            }
+            if (parts.length > 3) {
+                currency = parts[3];
+            }
+        }
+
+        if (StringUtils.isBlank(currency)) {
+            currency = Instrument.resolveCurrency(params.get("ticker"));
+        }
+        Map<String, String> regionCurrencyMap = Map.of("NY", "USD", "L", "GBP");
+        if ((StringUtils.isBlank(currency) || "UNKNOWN".equalsIgnoreCase(currency))
+                && regionCurrencyMap.containsKey(region.toUpperCase())) {
+            currency = regionCurrencyMap.get(region.toUpperCase());
+        }
+        Instrument instrument = Instrument.fromString(ticker, region, type, currency);
+
+        String category = params.get("category");
+        if (category != null && !category.equalsIgnoreCase(instrument.category())) {
+            return Collections.emptyList();
+        }
+
+        // Date handling
+        String fromDate = params.get("fromDate");
+        String toDate = params.get("toDate");
+        int years = Integer.parseInt(StringUtils.defaultIfEmpty(params.get("years"), "10"));
+        int months = Integer.parseInt(StringUtils.defaultIfEmpty(params.get("months"), "0"));
+        int weeks = Integer.parseInt(StringUtils.defaultIfEmpty(params.get("weeks"), "0"));
+        int days = Integer.parseInt(StringUtils.defaultIfEmpty(params.get("days"), "0"));
+
+        LocalDate toLocalDate;
+        LocalDate fromLocalDate;
+        if (StringUtils.isNotBlank(fromDate)) {
+            fromLocalDate = LocalDate.parse(fromDate);
+            toLocalDate = StringUtils.isBlank(toDate) ? LocalDate.now() : LocalDate.parse(toDate);
+        } else {
+            toLocalDate = LocalDate.now();
+            if (days > 0) {
+                fromLocalDate = LocalDate.now().plusDays(-days);
+            } else if (weeks > 0) {
+                fromLocalDate = LocalDate.now().plusWeeks(-weeks);
+            } else if (months > 0) {
+                fromLocalDate = LocalDate.now().plusMonths(-months);
+            } else {
+                fromLocalDate = LocalDate.now().plusYears(-years);
+            }
+        }
+
+        boolean interpolate = Boolean.parseBoolean(StringUtils.defaultIfEmpty(params.get("interpolate"), "false"));
+        boolean cleanData = Boolean.parseBoolean(StringUtils.defaultIfEmpty(params.get("cleanData"), "false"));
+        Double scaling = params.containsKey("scaling") ? Double.valueOf(params.get("scaling")) : null;
+
+        return generateRecords(instrument, fromLocalDate, toLocalDate, interpolate, cleanData, scaling);
+    }
+
+    /**
+     * Generates {@link DataField} records for the supplied instrument and period.
+     */
+    public List<List<DataField>> generateRecords(Instrument instrument,
+                                                 LocalDate fromLocalDate,
+                                                 LocalDate toLocalDate,
+                                                 boolean interpolate,
+                                                 boolean cleanData,
+                                                 Double scaling) throws IOException {
+        List<Bar> historyData = getHistoryData(instrument, fromLocalDate, toLocalDate, interpolate, cleanData, scaling);
+        List<List<DataField>> records = new ArrayList<>();
+        for (Bar historicalQuote : historyData) {
+            List<DataField> record = new ArrayList<>();
+            record.add(new DataField("Date", historicalQuote.getEndTime().atZone(ZoneId.systemDefault()).toLocalDate().toString()));
+            record.add(new DataField("Open", historicalQuote.getOpenPrice()));
+            record.add(new DataField("High", historicalQuote.getHighPrice()));
+            record.add(new DataField("Low", historicalQuote.getLowPrice()));
+            record.add(new DataField("Close", historicalQuote.getClosePrice()));
+            record.add(new DataField("Volume", historicalQuote.getVolume()));
+            if (historicalQuote instanceof Commentable commentable) {
+                record.add(new DataField("Comment", commentable.getComment()));
+            }
+            records.add(record);
+        }
+        return records;
+    }
+
+    private List<Bar> getHistoryData(Instrument instrument,
+                                     LocalDate fromLocalDate,
+                                     LocalDate toLocalDate,
+                                     boolean interpolate,
+                                     boolean cleanData,
+                                     Double scaling) throws IOException {
+        Optional<StockV1> stock = stockFeed.get(instrument, fromLocalDate, toLocalDate, interpolate, cleanData, false);
+        if (stock.isPresent()) {
+            List<Bar> history = stock.get().getHistory();
+            if (scaling != null) {
+                return new ValueScalingTransformer(instrument, scaling).clean(history);
+            }
+            return history;
+        }
+        return new ArrayList<>();
+    }
+}
+

--- a/timeseries-stockfeed/src/test/java/com/leonarduk/finance/stockfeed/HistoricalDataServiceTest.java
+++ b/timeseries-stockfeed/src/test/java/com/leonarduk/finance/stockfeed/HistoricalDataServiceTest.java
@@ -1,0 +1,78 @@
+package com.leonarduk.finance.stockfeed;
+
+import com.leonarduk.finance.stockfeed.feed.yahoofinance.StockV1;
+import com.leonarduk.finance.stockfeed.feed.ExtendedHistoricalQuote;
+import com.leonarduk.finance.utils.DataField;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+import org.ta4j.core.Bar;
+
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class HistoricalDataServiceTest {
+
+    @Test
+    void missingTickerThrows() {
+        HistoricalDataService service = new HistoricalDataService(Mockito.mock(StockFeed.class));
+        Assertions.assertThrows(IllegalArgumentException.class, () -> service.getRecords(null));
+        Assertions.assertThrows(IllegalArgumentException.class, () -> service.getRecords(Map.of()));
+    }
+
+    @Test
+    void categoryMismatchReturnsEmpty() throws IOException {
+        StockFeed feed = Mockito.mock(StockFeed.class);
+        HistoricalDataService service = new HistoricalDataService(feed);
+        List<List<DataField>> result = service.getRecords(Map.of("ticker", "TEST", "category", "EQUITY"));
+        Assertions.assertTrue(result.isEmpty());
+        Mockito.verifyNoInteractions(feed);
+    }
+
+    @Test
+    void scalingIsApplied() throws Exception {
+        StockFeed feed = Mockito.mock(StockFeed.class);
+        HistoricalDataService service = new HistoricalDataService(feed);
+        Instrument instrument = Instrument.fromString("TEST");
+        Bar bar = new ExtendedHistoricalQuote(instrument, LocalDate.parse("2024-01-01"),
+                BigDecimal.ONE, BigDecimal.ONE, BigDecimal.ONE, BigDecimal.valueOf(2), BigDecimal.ONE, 0L, "");
+        when(feed.get(eq(instrument), any(LocalDate.class), any(LocalDate.class), anyBoolean(), anyBoolean(), eq(false)))
+                .thenReturn(Optional.of(new StockV1(instrument, List.of(bar))));
+
+        Map<String,String> params = Map.of("ticker","TEST","scaling","2.0");
+        List<List<DataField>> records = service.getRecords(params);
+        Assertions.assertEquals(1, records.size());
+        Assertions.assertEquals("4.0", records.get(0).get(4).getValue().toString());
+    }
+
+    @Test
+    void fromAndToDatesParsedCorrectly() throws Exception {
+        StockFeed feed = Mockito.mock(StockFeed.class);
+        HistoricalDataService service = new HistoricalDataService(feed);
+        Instrument instrument = Instrument.fromString("TEST");
+        when(feed.get(eq(instrument), any(LocalDate.class), any(LocalDate.class), anyBoolean(), anyBoolean(), eq(false)))
+                .thenReturn(Optional.of(new StockV1(instrument, List.of())));
+
+        Map<String,String> params = Map.of(
+                "ticker","TEST",
+                "fromDate","2020-01-01",
+                "toDate","2020-01-10"
+        );
+        service.getRecords(params);
+        ArgumentCaptor<LocalDate> fromCaptor = ArgumentCaptor.forClass(LocalDate.class);
+        ArgumentCaptor<LocalDate> toCaptor = ArgumentCaptor.forClass(LocalDate.class);
+        verify(feed).get(eq(instrument), fromCaptor.capture(), toCaptor.capture(), anyBoolean(), anyBoolean(), eq(false));
+        Assertions.assertEquals(LocalDate.parse("2020-01-01"), fromCaptor.getValue());
+        Assertions.assertEquals(LocalDate.parse("2020-01-10"), toCaptor.getValue());
+    }
+}
+


### PR DESCRIPTION
## Summary
- add `HistoricalDataService` to consolidate request parsing and record generation
- refactor `StockFeedEndpoint` and `QueryRunner` to delegate to the service
- test `HistoricalDataService` for edge cases and update `QueryRunner` tests

## Testing
- `mvn -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a1a52ff4f883279281cba875cf957c