### PR TITLE
Return JSON for stock history and update UI

### DIFF
--- a/timeseries-lambda/pom.xml
+++ b/timeseries-lambda/pom.xml
@@ -54,6 +54,12 @@
             <version>1.12.788</version>
         </dependency>
 
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>2.17.1</version>
+        </dependency>
+
         <!-- https://mvnrepository.com/artifact/org.projectlombok/lombok -->
         <dependency>
             <groupId>org.projectlombok</groupId>

--- a/timeseries-lambda/src/main/java/com/leonarduk/aws/apigateway/ApiGatewayHandler.java
+++ b/timeseries-lambda/src/main/java/com/leonarduk/aws/apigateway/ApiGatewayHandler.java
@@ -45,12 +45,13 @@ public class ApiGatewayHandler
 
             if (this.s3Client != null && this.resultBucket != null && !this.resultBucket.isBlank()) {
                 String ticker = params != null ? params.get(QueryRunner.TICKER) : "result";
-                String key = "results/" + (ticker != null ? ticker : "result") + ".html";
+                String key = "results/" + (ticker != null ? ticker : "result") + ".json";
                 this.s3Client.putObject(this.resultBucket, key, result);
             }
 
             responseEvent.setBody(result);
             responseEvent.setStatusCode(200);
+            responseEvent.setHeaders(Map.of("Content-Type", "application/json"));
         } catch (SdkClientException e) {
             responseEvent.setBody("S3_ERROR: " + e.getMessage());
             responseEvent.setStatusCode(502);

--- a/timeseries-lambda/src/test/java/com/leonarduk/aws/apigateway/ApiGatewayHandlerTest.java
+++ b/timeseries-lambda/src/test/java/com/leonarduk/aws/apigateway/ApiGatewayHandlerTest.java
@@ -29,7 +29,7 @@ class ApiGatewayHandlerTest {
     void uploadsResultToS3() throws Exception {
         AmazonS3 s3 = Mockito.mock(AmazonS3.class);
         QueryRunner runner = Mockito.mock(QueryRunner.class);
-        Mockito.when(runner.getResults(Mockito.any())).thenReturn("HTML");
+        Mockito.when(runner.getResults(Mockito.any())).thenReturn("JSON");
 
         ApiGatewayHandler handler = buildHandler(s3, runner, "bucket");
 
@@ -39,7 +39,7 @@ class ApiGatewayHandlerTest {
         APIGatewayProxyResponseEvent response = handler.handleRequest(request, null);
 
         Assertions.assertEquals(200, response.getStatusCode());
-        Mockito.verify(s3).putObject(Mockito.eq("bucket"), Mockito.eq("results/TEST.html"), Mockito.anyString());
+        Mockito.verify(s3).putObject(Mockito.eq("bucket"), Mockito.eq("results/TEST.json"), Mockito.anyString());
     }
 
     @Test
@@ -48,7 +48,7 @@ class ApiGatewayHandlerTest {
         Mockito.doThrow(new AmazonServiceException("fail"))
                 .when(s3).putObject(Mockito.anyString(), Mockito.anyString(), Mockito.anyString());
         QueryRunner runner = Mockito.mock(QueryRunner.class);
-        Mockito.when(runner.getResults(Mockito.any())).thenReturn("HTML");
+        Mockito.when(runner.getResults(Mockito.any())).thenReturn("JSON");
 
         ApiGatewayHandler handler = buildHandler(s3, runner, "bucket");
 

--- a/timeseries-spring-boot-server/src/test/java/com/leonarduk/finance/springboot/StockFeedEndpointTest.java
+++ b/timeseries-spring-boot-server/src/test/java/com/leonarduk/finance/springboot/StockFeedEndpointTest.java
@@ -18,7 +18,6 @@ import java.time.LocalDate;
 import java.util.Collections;
 import java.util.Optional;
 
-import static org.hamcrest.Matchers.containsString;
 import static org.mockito.ArgumentMatchers.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -37,7 +36,7 @@ class StockFeedEndpointTest {
     private JavaMailSender mailSender;
 
     @Test
-    void displayHistoryReturnsHtmlTable() throws Exception {
+    void displayHistoryReturnsJsonData() throws Exception {
         Instrument instrument = Instrument.CASH;
         StockV1 stock = AbstractStockFeed.createStock(instrument, Collections.emptyList());
         Mockito.when(stockFeed.get(argThat(i -> i.getCode().equals("CASH")), eq(LocalDate.parse("2024-01-01")),
@@ -51,8 +50,8 @@ class StockFeedEndpointTest {
                         .param("cleanDate", "true")
                         .param("category", "Cash"))
                 .andExpect(status().isOk())
-                .andExpect(content().contentTypeCompatibleWith(MediaType.TEXT_HTML))
-                .andExpect(content().string(containsString("<html")));
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(content().json("[]"));
     }
 
     @Test

--- a/ui/src/App.test.jsx
+++ b/ui/src/App.test.jsx
@@ -17,7 +17,7 @@ afterEach(() => {
 });
 
 test('loads and displays data with charts and toggles view', async () => {
-  const mockTickerData = { AAPL: { '2024-01-01': 100 } };
+  const mockTickerData = [{ Date: '2024-01-01', Close: 100 }];
   const mockRiskData = [
     { ticker: 'AAPL', annual_std: 0.1, annual_return: 0.2 },
   ];
@@ -34,9 +34,9 @@ test('loads and displays data with charts and toggles view', async () => {
   );
   fireEvent.click(screen.getByText('Load'));
 
-  await screen.findByText('AAPL');
+  await screen.findAllByText('AAPL');
   expect(global.fetch).toHaveBeenCalledTimes(2);
-  expect(screen.getByText('100')).toBeTruthy();
+  expect(screen.getAllByText('100')[0]).toBeTruthy();
   expect(screen.getByTestId('line-chart')).toBeTruthy();
   expect(screen.getByTestId('scatter-chart')).toBeTruthy();
 

--- a/ui/src/TickerTable.jsx
+++ b/ui/src/TickerTable.jsx
@@ -1,18 +1,16 @@
 import React from 'react';
 
 export default function TickerTable({ data, viewMode = 'total' }) {
-  const total = Object.values(data).reduce((sum, prices) => {
-    const dates = Object.keys(prices);
-    const latestDate = dates[dates.length - 1];
-    const latestPrice = prices[latestDate];
+  const total = Object.values(data).reduce((sum, records) => {
+    const latest = records[records.length - 1];
+    const latestPrice = latest ? latest.Close : 0;
     return sum + latestPrice;
   }, 0);
 
   const renderRows = () =>
-    Object.entries(data).map(([ticker, prices]) => {
-      const dates = Object.keys(prices);
-      const latestDate = dates[dates.length - 1];
-      const latestPrice = prices[latestDate];
+    Object.entries(data).map(([ticker, records]) => {
+      const latest = records[records.length - 1];
+      const latestPrice = latest ? latest.Close : 0;
       const value =
         viewMode === 'relative' && total > 0
           ? (latestPrice / total).toFixed(2)

--- a/ui/src/TickerTable.test.jsx
+++ b/ui/src/TickerTable.test.jsx
@@ -4,8 +4,8 @@ import { expect, test } from 'vitest';
 import TickerTable from './TickerTable.jsx';
 
 const sampleData = {
-  AAA: { '2024-01-01': 1 },
-  BBB: { '2024-01-01': 3 },
+  AAA: [{ Date: '2024-01-01', Close: 1 }],
+  BBB: [{ Date: '2024-01-01', Close: 3 }],
 };
 
 function Wrapper() {

--- a/ui/src/__snapshots__/App.test.jsx.snap
+++ b/ui/src/__snapshots__/App.test.jsx.snap
@@ -3,6 +3,23 @@
 exports[`loads and displays data with charts and toggles view 1`] = `
 <DocumentFragment>
   <div>
+    <nav>
+      <a
+        href="#ticker-table"
+      >
+        Table
+      </a>
+      <a
+        href="#price-chart"
+      >
+        Price Chart
+      </a>
+      <a
+        href="#risk-return"
+      >
+        Risk/Return
+      </a>
+    </nav>
     <h1>
       Pension Risk Management
     </h1>
@@ -17,6 +34,30 @@ exports[`loads and displays data with charts and toggles view 1`] = `
     <button>
       View: relative
     </button>
+    <table
+      id="ticker-table"
+    >
+      <thead>
+        <tr>
+          <th>
+            Ticker
+          </th>
+          <th>
+            Latest Close
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>
+            AAPL
+          </td>
+          <td>
+            100
+          </td>
+        </tr>
+      </tbody>
+    </table>
     <table>
       <thead>
         <tr>
@@ -40,6 +81,7 @@ exports[`loads and displays data with charts and toggles view 1`] = `
       </tbody>
     </table>
     <div
+      id="price-chart"
       style="max-width: 600px;"
     >
       <div
@@ -47,6 +89,7 @@ exports[`loads and displays data with charts and toggles view 1`] = `
       />
     </div>
     <div
+      id="risk-return"
       style="max-width: 600px; margin-top: 20px;"
     >
       <div


### PR DESCRIPTION
## Summary
- return structured JSON from StockFeedEndpoint instead of HTML tables
- generate JSON in Lambda QueryRunner and store `.json` results in S3
- update React UI to fetch new JSON format and render tables and charts

## Testing
- `mvn -q -pl timeseries-spring-boot-server,timeseries-lambda -am test` *(fails: Network is unreachable)*
- `npm test -- -u`

------
https://chatgpt.com/codex/tasks/task_e_68a1a533d9748327aada2deb3f05d14d