### PR TITLE
Add basic time series source interface with caching decorator

### DIFF
--- a/timeseries-sources/src/main/java/com/leonarduk/finance/timeseries/CachingTimeSeriesSource.java
+++ b/timeseries-sources/src/main/java/com/leonarduk/finance/timeseries/CachingTimeSeriesSource.java
@@ -1,0 +1,47 @@
+package com.leonarduk.finance.timeseries;
+
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+import java.io.IOException;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+import yahoofinance.histquotes.HistoricalQuote;
+
+/**
+ * Decorator that caches results from another {@link TimeSeriesSource} in memory
+ * using Guava's {@link LoadingCache}.
+ */
+public class CachingTimeSeriesSource implements TimeSeriesSource {
+
+    private final TimeSeriesSource delegate;
+    private final LoadingCache<String, List<HistoricalQuote>> cache;
+
+    /**
+     * Create a caching layer around the provided {@code delegate}.
+     *
+     * @param delegate source used to load data on cache miss
+     */
+    public CachingTimeSeriesSource(TimeSeriesSource delegate) {
+        this.delegate = delegate;
+        this.cache = CacheBuilder.newBuilder().build(new CacheLoader<String, List<HistoricalQuote>>() {
+            @Override
+            public List<HistoricalQuote> load(String key) throws Exception {
+                return delegate.getTimeSeries(key);
+            }
+        });
+    }
+
+    @Override
+    public List<HistoricalQuote> getTimeSeries(String symbol) throws IOException {
+        try {
+            return cache.get(symbol);
+        } catch (ExecutionException e) {
+            Throwable cause = e.getCause();
+            if (cause instanceof IOException io) {
+                throw io;
+            }
+            throw new IOException("Failed to load time series for " + symbol, cause);
+        }
+    }
+}

--- a/timeseries-sources/src/main/java/com/leonarduk/finance/timeseries/TimeSeriesSource.java
+++ b/timeseries-sources/src/main/java/com/leonarduk/finance/timeseries/TimeSeriesSource.java
@@ -1,0 +1,20 @@
+package com.leonarduk.finance.timeseries;
+
+import java.io.IOException;
+import java.util.List;
+import yahoofinance.histquotes.HistoricalQuote;
+
+/**
+ * Defines the contract for acquiring time‑series data for financial instruments.
+ * Implementations may retrieve data from remote services or local stores.
+ */
+public interface TimeSeriesSource {
+    /**
+     * Retrieve the time‑series for the given symbol.
+     *
+     * @param symbol instrument identifier
+     * @return list of historical quotes ordered by date
+     * @throws IOException if the data cannot be retrieved
+     */
+    List<HistoricalQuote> getTimeSeries(String symbol) throws IOException;
+}


### PR DESCRIPTION
## Summary
- Introduce `TimeSeriesSource` interface documenting the contract for acquiring time-series data
- Add `CachingTimeSeriesSource` decorator to demonstrate simple in-memory caching

## Testing
- `mvn -f timeseries-sources/pom.xml -e test`


------
https://chatgpt.com/codex/tasks/task_e_68a1a52eb4408327835520af51ab879a