### PR TITLE
Mock HTTP calls and stabilize tests

### DIFF
--- a/alphavantage4j/pom.xml
+++ b/alphavantage4j/pom.xml
@@ -42,6 +42,12 @@
             <version>${junit5.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.github.tomakehurst</groupId>
+            <artifactId>wiremock-jre8</artifactId>
+            <version>2.35.0</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/alphavantage4j/src/main/java/org/patriques/AlphaVantageConnector.java
+++ b/alphavantage4j/src/main/java/org/patriques/AlphaVantageConnector.java
@@ -16,9 +16,10 @@ import org.patriques.output.AlphaVantageException;
  * @see ApiConnector
  */
 public class AlphaVantageConnector implements ApiConnector {
-  private static final String BASE_URL = "https://www.alphavantage.co/query?";
+  private static final String DEFAULT_BASE_URL = "https://www.alphavantage.co/query?";
   private final String apiKey;
   private final int timeOut;
+  private final String baseUrl;
 
   /**
    * Creates an AlphaVantageConnector.
@@ -27,15 +28,28 @@ public class AlphaVantageConnector implements ApiConnector {
    * @param timeOut the timeout for when reading the connection should give up.
    */
   public AlphaVantageConnector(String apiKey, int timeOut) {
+    this(apiKey, timeOut, DEFAULT_BASE_URL);
+  }
+
+  /**
+   * Creates an AlphaVantageConnector with a custom base URL. Primarily used for
+   * testing to point at a mock HTTP server.
+   *
+   * @param apiKey the secret key to access the api.
+   * @param timeOut the timeout for when reading the connection should give up.
+   * @param baseUrl base URL including query path and trailing question mark.
+   */
+  public AlphaVantageConnector(String apiKey, int timeOut, String baseUrl) {
     this.apiKey = apiKey;
     this.timeOut = timeOut;
+    this.baseUrl = baseUrl;
   }
 
   @Override
   public String getRequest(ApiParameter... apiParameters) {
     String params = getParameters(apiParameters);
     try {
-      URL request = new URL(BASE_URL + params);
+      URL request = new URL(baseUrl + params);
       URLConnection connection = request.openConnection();
       connection.setConnectTimeout(timeOut);
       connection.setReadTimeout(timeOut);

--- a/alphavantage4j/src/test/java/org/patriques/AlphaVantageConnectorTest.java
+++ b/alphavantage4j/src/test/java/org/patriques/AlphaVantageConnectorTest.java
@@ -1,104 +1,66 @@
 package org.patriques;
 
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.http.Fault;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.patriques.input.Function;
 import org.patriques.input.Symbol;
 import org.patriques.output.AlphaVantageException;
 
-import java.io.ByteArrayInputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.net.URL;
-import java.net.URLConnection;
-import java.net.URLStreamHandler;
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
 import static org.junit.jupiter.api.Assertions.*;
 
+/**
+ * Tests for {@link AlphaVantageConnector} that mock HTTP calls using WireMock.
+ */
 public class AlphaVantageConnectorTest {
-    private static final MockURLStreamHandler URL_HANDLER = new MockURLStreamHandler();
 
-    @BeforeAll
-    public static void initUrlHandler() {
-        URL.setURLStreamHandlerFactory(protocol -> "https".equals(protocol) ? URL_HANDLER : null);
-    }
+    private WireMockServer wireMockServer;
 
     @BeforeEach
-    public void resetHandler() {
-        URL_HANDLER.reset();
+    void setUp() {
+        wireMockServer = new WireMockServer();
+        wireMockServer.start();
+        configureFor("localhost", wireMockServer.port());
+    }
+
+    @AfterEach
+    void tearDown() {
+        wireMockServer.stop();
     }
 
     @Test
     public void testGetRequestBuildsUrlAndReturnsResponse() {
-        URL_HANDLER.setResponse("{\"result\":\"ok\"}");
-        AlphaVantageConnector connector = new AlphaVantageConnector("demo", 5000);
+        stubFor(get(urlPathEqualTo("/query"))
+                .withQueryParam("function", equalTo("TIME_SERIES_DAILY"))
+                .withQueryParam("symbol", equalTo("IBM"))
+                .withQueryParam("apikey", equalTo("demo"))
+                .willReturn(aResponse().withBody("{\"result\":\"ok\"}")));
+
+        AlphaVantageConnector connector =
+                new AlphaVantageConnector("demo", 5000, wireMockServer.baseUrl() + "/query?");
+
         String response = connector.getRequest(Function.TIME_SERIES_DAILY, new Symbol("IBM"));
+
         assertEquals("{\"result\":\"ok\"}", response);
-        assertEquals("https://www.alphavantage.co/query?&function=TIME_SERIES_DAILY&symbol=IBM&apikey=demo",
-                URL_HANDLER.getLastUrl().toString());
+        wireMockServer.verify(getRequestedFor(urlPathEqualTo("/query"))
+                .withQueryParam("function", equalTo("TIME_SERIES_DAILY"))
+                .withQueryParam("symbol", equalTo("IBM"))
+                .withQueryParam("apikey", equalTo("demo")));
     }
 
     @Test
     public void testGetRequestThrowsAlphaVantageExceptionOnIoError() {
-        URL_HANDLER.setThrowIOException(true);
-        AlphaVantageConnector connector = new AlphaVantageConnector("demo", 5000);
-        assertThrows(
-                AlphaVantageException.class,
+        stubFor(get(urlPathEqualTo("/query"))
+                .willReturn(aResponse().withFault(Fault.CONNECTION_RESET_BY_PEER)));
+
+        AlphaVantageConnector connector =
+                new AlphaVantageConnector("demo", 5000, wireMockServer.baseUrl() + "/query?");
+
+        assertThrows(AlphaVantageException.class,
                 () -> connector.getRequest(Function.TIME_SERIES_DAILY));
     }
-
-    private static class MockURLStreamHandler extends URLStreamHandler {
-        private URL lastUrl;
-        private String response;
-        private boolean throwIOException;
-
-        void setResponse(String response) {
-            this.response = response;
-            this.throwIOException = false;
-        }
-
-        void setThrowIOException(boolean throwIOException) {
-            this.throwIOException = throwIOException;
-        }
-
-        void reset() {
-            this.lastUrl = null;
-            this.response = null;
-            this.throwIOException = false;
-        }
-
-        URL getLastUrl() {
-            return lastUrl;
-        }
-
-        @Override
-        protected URLConnection openConnection(URL u) {
-            this.lastUrl = u;
-            return new MockURLConnection(u, response, throwIOException);
-        }
-    }
-
-    private static class MockURLConnection extends URLConnection {
-        private final String response;
-        private final boolean throwIOException;
-
-        protected MockURLConnection(URL url, String response, boolean throwIOException) {
-            super(url);
-            this.response = response;
-            this.throwIOException = throwIOException;
-        }
-
-        @Override
-        public void connect() {
-            // no-op
-        }
-
-        @Override
-        public InputStream getInputStream() throws IOException {
-            if (throwIOException) {
-                throw new IOException("forced exception");
-            }
-            return new ByteArrayInputStream(response.getBytes());
-        }
-    }
 }
+

--- a/timeseries-stockfeed/src/test/java/com/leonarduk/finance/stockfeed/CachedStockFeedTest.java
+++ b/timeseries-stockfeed/src/test/java/com/leonarduk/finance/stockfeed/CachedStockFeedTest.java
@@ -18,8 +18,9 @@ public class CachedStockFeedTest {
         DataStore store = Mockito.mock(DataStore.class);
         CachedStockFeed feed = new CachedStockFeed(store);
         Instrument instrument = new FxInstrument(Source.MANUAL, "USD", "GBP");
+        LocalDate date = LocalDate.of(2024, 1, 2);
         List<Bar> history = List.of(
-                new ExtendedHistoricalQuote(instrument, LocalDate.now().minusDays(1), 1d, 1d, 1d, 1d, 1d, 0L, "orig"));
+                new ExtendedHistoricalQuote(instrument, date.minusDays(1), 1d, 1d, 1d, 1d, 1d, 0L, "orig"));
         StockV1 cached = new StockV1(instrument, history);
         Mockito.when(store.get(instrument, 1000, false)).thenReturn(Optional.of(cached));
 
@@ -47,12 +48,13 @@ public class CachedStockFeedTest {
         CachedStockFeed feed = new CachedStockFeed(store);
         Instrument instrument = new FxInstrument(Source.MANUAL, "USD", "GBP");
 
+        LocalDate date = LocalDate.of(2024, 1, 3);
         List<Bar> originalHistory = List.of(
-                new ExtendedHistoricalQuote(instrument, LocalDate.now().minusDays(2), 1d, 1d, 1d, 1d, 1d, 0L, "orig"));
+                new ExtendedHistoricalQuote(instrument, date.minusDays(2), 1d, 1d, 1d, 1d, 1d, 0L, "orig"));
         StockV1 originalStock = new StockV1(instrument, originalHistory);
 
         List<Bar> newHistory = List.of(
-                new ExtendedHistoricalQuote(instrument, LocalDate.now().minusDays(1), 2d, 2d, 2d, 2d, 2d, 0L, "new"));
+                new ExtendedHistoricalQuote(instrument, date.minusDays(1), 2d, 2d, 2d, 2d, 2d, 0L, "new"));
         StockV1 newStock = new StockV1(instrument, newHistory);
 
         Mockito.when(store.contains(newStock)).thenReturn(true);

--- a/timeseries-stockfeed/src/test/java/com/leonarduk/finance/stockfeed/FxFeedTest.java
+++ b/timeseries-stockfeed/src/test/java/com/leonarduk/finance/stockfeed/FxFeedTest.java
@@ -15,8 +15,8 @@ public class FxFeedTest {
     @Test
     public void testGetFxSeriesReturnsData() {
         FxFeed mockFeed = Mockito.mock(FxFeed.class);
-        LocalDate from = LocalDate.now().minusDays(1);
-        LocalDate to = LocalDate.now();
+        LocalDate to = LocalDate.of(2024, 1, 2);
+        LocalDate from = to.minusDays(1);
         Instrument instrument = new FxInstrument(Source.MANUAL, "USD", "GBP");
         List<Bar> series = List.of(
                 new ExtendedHistoricalQuote(instrument, from, 1d, 1d, 1d, 1d, 1d, 0L, "test"),
@@ -30,8 +30,8 @@ public class FxFeedTest {
     @Test
     public void testGetFxSeriesUnknownPairReturnsEmptyList() {
         FxFeed mockFeed = Mockito.mock(FxFeed.class);
-        LocalDate from = LocalDate.now().minusDays(1);
-        LocalDate to = LocalDate.now();
+        LocalDate to = LocalDate.of(2024, 1, 2);
+        LocalDate from = to.minusDays(1);
         Mockito.when(mockFeed.getFxSeries("AAA", "BBB", from, to)).thenReturn(Collections.emptyList());
 
         List<Bar> result = mockFeed.getFxSeries("AAA", "BBB", from, to);

--- a/timeseries-stockfeed/src/test/java/com/leonarduk/finance/stockfeed/feed/stooq/StooqFeedLimiterTest.java
+++ b/timeseries-stockfeed/src/test/java/com/leonarduk/finance/stockfeed/feed/stooq/StooqFeedLimiterTest.java
@@ -27,15 +27,19 @@ public class StooqFeedLimiterTest {
     @Test
     public void testLimitExceeded() throws IOException {
         TestStooqFeed feed = new TestStooqFeed();
-        feed.get(Instrument.fromString("AAA"), LocalDate.now().minusDays(1), LocalDate.now(), false);
-        feed.get(Instrument.fromString("BBB"), LocalDate.now().minusDays(1), LocalDate.now(), false);
+        LocalDate end = LocalDate.of(2024, 1, 2);
+        LocalDate start = end.minusDays(1);
+        feed.get(Instrument.fromString("AAA"), start, end, false);
+        feed.get(Instrument.fromString("BBB"), start, end, false);
+        LocalDate finalStart = start;
+        LocalDate finalEnd = end;
         Assertions.assertThrows(
                 DailyLimitExceededException.class,
                 () ->
                         feed.get(
                                 Instrument.fromString("CCC"),
-                                LocalDate.now().minusDays(1),
-                                LocalDate.now(),
+                                finalStart,
+                                finalEnd,
                                 false));
     }
 


### PR DESCRIPTION
## Summary
- inject configurable base URL into AlphaVantageConnector and mock HTTP with WireMock
- add WireMock dependency and replace custom URL handling in tests
- stabilize stock feed tests by using fixed dates

## Testing
- `pre-commit run --files alphavantage4j/pom.xml alphavantage4j/src/main/java/org/patriques/AlphaVantageConnector.java alphavantage4j/src/test/java/org/patriques/AlphaVantageConnectorTest.java timeseries-stockfeed/src/test/java/com/leonarduk/finance/stockfeed/CachedStockFeedTest.java timeseries-stockfeed/src/test/java/com/leonarduk/finance/stockfeed/FxFeedTest.java timeseries-stockfeed/src/test/java/com/leonarduk/finance/stockfeed/feed/stooq/StooqFeedLimiterTest.java`
- `mvn -Dsurefire.rerunFailingTestsCount=2 test` *(failed: Non-resolvable parent POM – network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a1b10be0948327a511f8ea2ed80706