### PR TITLE
refactor: standardize logging

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,6 +30,7 @@
         <org.apache.commons.version>3.18.0</org.apache.commons.version>
         <javax.xml.bind.version>2.4.0-b180830.0359</javax.xml.bind.version>
         <lombok.version>1.18.38</lombok.version>
+        <logback.version>1.5.18</logback.version>
     </properties>
 
     <build>
@@ -163,9 +164,9 @@
                 <version>${org.slf4j.version}</version>
             </dependency>
             <dependency>
-                <groupId>org.slf4j</groupId>
-                <artifactId>slf4j-simple</artifactId>
-                <version>${org.slf4j.version}</version>
+                <groupId>ch.qos.logback</groupId>
+                <artifactId>logback-classic</artifactId>
+                <version>${logback.version}</version>
             </dependency>
 
             <dependency>

--- a/timeseries-lambda/pom.xml
+++ b/timeseries-lambda/pom.xml
@@ -22,12 +22,10 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>2.0.17</version>
         </dependency>
         <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-slf4j2-impl</artifactId>
-            <version>2.23.1</version>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
         </dependency>
 
         <!-- Test Dependencies -->

--- a/timeseries-lambda/src/main/java/com/leonarduk/aws/apigateway/ApiGatewayHandler.java
+++ b/timeseries-lambda/src/main/java/com/leonarduk/aws/apigateway/ApiGatewayHandler.java
@@ -9,6 +9,7 @@ import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3ClientBuilder;
 import com.leonarduk.aws.QueryRunner;
+import lombok.extern.slf4j.Slf4j;
 
 import java.io.IOException;
 import java.util.Map;
@@ -19,6 +20,7 @@ import java.util.Map;
  *
  * @see <a href=https://docs.aws.amazon.com/lambda/latest/dg/java-handler.html>Lambda Java Handler</a> for more information
  */
+@Slf4j
 public class ApiGatewayHandler
         implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
 
@@ -56,7 +58,7 @@ public class ApiGatewayHandler
             responseEvent.setBody("S3_ERROR: " + e.getMessage());
             responseEvent.setStatusCode(502);
         } catch (IOException e) {
-            e.printStackTrace();
+            log.error("Failed to handle request", e);
             responseEvent.setBody("FAILED: " + e.getMessage());
             responseEvent.setStatusCode(500);
         }

--- a/timeseries-sources/pom.xml
+++ b/timeseries-sources/pom.xml
@@ -95,7 +95,6 @@
                 <dependency>
                         <groupId>ch.qos.logback</groupId>
                         <artifactId>logback-classic</artifactId>
-                        <version>1.5.18</version>
                 </dependency>
 		<dependency>
 			<groupId>org.apache.commons</groupId>
@@ -135,7 +134,6 @@
                <dependency>
                        <groupId>org.slf4j</groupId>
                        <artifactId>slf4j-api</artifactId>
-                       <version>2.0.17</version>
                </dependency>
 		<!-- ta4j -->
 		<dependency>

--- a/timeseries-stockfeed/src/main/java/com/leonarduk/finance/stockfeed/feed/yahoofinance/StockV1.java
+++ b/timeseries-stockfeed/src/main/java/com/leonarduk/finance/stockfeed/feed/yahoofinance/StockV1.java
@@ -211,16 +211,16 @@ public class StockV1 {
     }
 
     public void print() {
-        System.out.println(this.getSymbol());
-        System.out.println("--------------------------------");
+        log.info(this.getSymbol());
+        log.info("--------------------------------");
         for (final Field f : this.getClass().getDeclaredFields()) {
             try {
-                System.out.println(f.getName() + ": " + f.get(this));
+                log.info("{}: {}", f.getName(), f.get(this));
             } catch (final IllegalArgumentException | IllegalAccessException ex) {
-                log.error(null, ex);
+                log.error("Error accessing field", ex);
             }
         }
-        System.out.println("--------------------------------");
+        log.info("--------------------------------");
     }
 
     @Override

--- a/timeseries-stockfeed/src/test/java/com/leonarduk/finance/stockfeed/feed/ft/FTFeedTest.java
+++ b/timeseries-stockfeed/src/test/java/com/leonarduk/finance/stockfeed/feed/ft/FTFeedTest.java
@@ -2,6 +2,7 @@ package com.leonarduk.finance.stockfeed.feed.ft;
 
 import com.leonarduk.finance.stockfeed.Instrument;
 import com.leonarduk.finance.stockfeed.feed.yahoofinance.StockV1;
+import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
@@ -9,6 +10,7 @@ import org.junit.jupiter.api.Test;
 import java.io.IOException;
 import java.util.Optional;
 
+@Slf4j
 public class FTFeedTest {
 
     FTFeed feed;
@@ -23,7 +25,7 @@ public class FTFeedTest {
     public void get() throws IOException {
         Optional<StockV1> result = feed.get(Instrument.fromString("PHGP"), 1, false);
         if (result.isPresent()) {
-            System.out.println(result.get().getHistory());
+            log.info("{}", result.get().getHistory());
         }
     }
 }


### PR DESCRIPTION
## Summary
- manage `logback-classic` centrally and remove `slf4j-simple`
- switch remaining modules from Log4j binding to `logback-classic`
- replace console printing with structured logging

## Testing
- `pre-commit run --files pom.xml timeseries-lambda/pom.xml timeseries-sources/pom.xml timeseries-stockfeed/src/main/java/com/leonarduk/finance/stockfeed/feed/yahoofinance/StockV1.java timeseries-stockfeed/src/test/java/com/leonarduk/finance/stockfeed/feed/ft/FTFeedTest.java timeseries-lambda/src/main/java/com/leonarduk/aws/apigateway/ApiGatewayHandler.java`
- `mvn -q test` *(fails: Non-resolvable parent POM: Network is unreachable)*


------
https://chatgpt.com/codex/tasks/task_e_68a1b10a83d4832789c964f3458dae07