### PR TITLE
chore: update openapi and jackson

### DIFF
--- a/timeseries-spring-boot-server/pom.xml
+++ b/timeseries-spring-boot-server/pom.xml
@@ -25,9 +25,10 @@
                 <rest.assured.version>5.5.0</rest.assured.version>
                 <maven.compiler.release>21</maven.compiler.release>
                 <jacoco.version>0.8.13</jacoco.version>
-		<jahoo.finance.version>3.15.0</jahoo.finance.version>
-		<org.ta4j.version>0.18</org.ta4j.version>
-	</properties>
+                <jahoo.finance.version>3.15.0</jahoo.finance.version>
+                <org.ta4j.version>0.18</org.ta4j.version>
+                <jackson.version>2.17.3</jackson.version>
+        </properties>
 
         <repositories>
                 <repository>
@@ -117,7 +118,13 @@
         <dependency>
             <groupId>org.springdoc</groupId>
             <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
-            <version>2.8.6</version>
+            <version>2.8.9</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>${jackson.version}</version>
         </dependency>
 
     </dependencies>


### PR DESCRIPTION
## Summary
- pin Jackson Databind to version 2.17.3
- bump SpringDoc OpenAPI UI to 2.8.9

## Testing
- `mvn -pl timeseries-spring-boot-server spring-boot:run` *(fails: Non-resolvable parent POM ... network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a1b0ffedcc83279ae010288271a6f9