### PR TITLE
refactor: centralize junit version

### DIFF
--- a/timeseries-lambda/pom.xml
+++ b/timeseries-lambda/pom.xml
@@ -34,7 +34,7 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
-            <version>5.13.0-M3</version>
+            <version>${junit5.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/timeseries-sources/pom.xml
+++ b/timeseries-sources/pom.xml
@@ -20,7 +20,6 @@
                 <start-class>com.leonarduk.finance.springboot.App</start-class>
                 <jakarta.persistence.version>3.2.0</jakarta.persistence.version>
                 <org.seleniumhq.selenium.version>4.13.0</org.seleniumhq.selenium.version>
-                <org.junit.jupiter.version>5.13.0-M3</org.junit.jupiter.version>
                 <org.ta4j.version>0.18</org.ta4j.version>
                 <org.jfree.version>3.4.4</org.jfree.version>
                 <org.apache.xmlgraphics.version>1.19</org.apache.xmlgraphics.version>
@@ -169,10 +168,10 @@
                         <version>2.13.1</version>
                </dependency>
                <dependency>
-                        <groupId>org.junit.jupiter</groupId>
-                        <artifactId>junit-jupiter</artifactId>
-                        <version>${org.junit.jupiter.version}</version>
-                        <scope>test</scope>
+                       <groupId>org.junit.jupiter</groupId>
+                       <artifactId>junit-jupiter</artifactId>
+                       <version>${junit5.version}</version>
+                       <scope>test</scope>
                </dependency>
     </dependencies>
 	<build>


### PR DESCRIPTION
## Summary
- use parent-managed junit5 version for lambda module
- drop junit version override in sources module

## Testing
- `mvn -pl timeseries-lambda test` *(fails: Non-resolvable parent POM for timeseries-spring-boot-server: The following artifacts could not be resolved: org.springframework.boot:spring-boot-starter-parent:pom:3.3.13 (absent): Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.3.13 from/to central (https://repo1.maven.org/maven2/): Network is unreachable and 'parent.relativePath' points at no local POM)*


------
https://chatgpt.com/codex/tasks/task_e_68a1b0ff6a508327a27eb1513f8eda05