### PR TITLE
chore: update alphavantage4j dependencies

### DIFF
--- a/alphavantage4j/pom.xml
+++ b/alphavantage4j/pom.xml
@@ -20,14 +20,14 @@
             <version>3.0.2</version>
         </dependency>
         <dependency>
-            <groupId>javax.annotation</groupId>
-            <artifactId>javax.annotation-api</artifactId>
-            <version>1.3.2</version>
-        </dependency>
-        <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
-            <version>2.8.5</version>
+            <version>2.13.1</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jetbrains</groupId>
+            <artifactId>annotations</artifactId>
+            <version>26.0.2</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.projectlombok/lombok -->
         <dependency>

--- a/alphavantage4j/src/main/java/org/patriques/TechnicalIndicators.java
+++ b/alphavantage4j/src/main/java/org/patriques/TechnicalIndicators.java
@@ -1,6 +1,6 @@
 package org.patriques;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 
 import org.patriques.input.Function;
 import org.patriques.input.Symbol;

--- a/alphavantage4j/src/main/java/org/patriques/input/ApiParameterBuilder.java
+++ b/alphavantage4j/src/main/java/org/patriques/input/ApiParameterBuilder.java
@@ -2,7 +2,7 @@ package org.patriques.input;
 
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Builder for api parameters.


### PR DESCRIPTION
## Summary
- remove javax.annotation and switch to JetBrains annotations
- bump Gson to 2.13.1
- ensure JUnit Jupiter remains as test framework

## Testing
- `mvn -Djava.net.preferIPv4Stack=true test` *(fails: Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin:pom:3.3.1 from/to central (https://repo1.maven.org/maven2/): Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a1b0fc64488327afb7d20cab17654b