### PR TITLE
refactor: use StandardCharsets in AlphaVantageConnector

### DIFF
--- a/alphavantage4j/src/main/java/org/patriques/AlphaVantageConnector.java
+++ b/alphavantage4j/src/main/java/org/patriques/AlphaVantageConnector.java
@@ -5,6 +5,7 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.net.URL;
 import java.net.URLConnection;
+import java.nio.charset.StandardCharsets;
 
 import org.patriques.input.ApiParameter;
 import org.patriques.input.ApiParameterBuilder;
@@ -43,7 +44,7 @@ public class AlphaVantageConnector implements ApiConnector {
       StringBuilder responseBuilder = new StringBuilder();
 
       try (InputStreamReader inputStream =
-              new InputStreamReader(connection.getInputStream(), "UTF-8");
+              new InputStreamReader(connection.getInputStream(), StandardCharsets.UTF_8);
           BufferedReader bufferedReader = new BufferedReader(inputStream)) {
         String line;
         while ((line = bufferedReader.readLine()) != null) {


### PR DESCRIPTION
## Summary
- use `StandardCharsets.UTF_8` for reading API responses

## Testing
- `mvn -DskipTests compile` *(fails: Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin:pom:3.3.1 from/to central (https://repo1.maven.org/maven2/): Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a1b7cd2d7c8327b31e0bee42e6083f