### PR TITLE
fix: replace deprecated URL constructor

### DIFF
--- a/timeseries-stockfeed/src/main/java/com/leonarduk/finance/stockfeed/feed/ft/FTTimeSeriesPage.java
+++ b/timeseries-stockfeed/src/main/java/com/leonarduk/finance/stockfeed/feed/ft/FTTimeSeriesPage.java
@@ -16,7 +16,8 @@ import org.ta4j.core.Bar;
 import java.io.BufferedReader;
 import java.io.InputStreamReader;
 import java.net.HttpURLConnection;
-import java.net.URL;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.time.LocalDate;
 import java.time.ZoneId;
@@ -98,9 +99,10 @@ public class FTTimeSeriesPage {
             String url = String.format("%s%sstartDate=%s&endDate=%s&format=csv", expectedUrl,
                     expectedUrl.contains("?") ? "&" : "?", fromDateString, toDateString);
             log.info("CSV fallback {}", url);
-            HttpURLConnection connection = (HttpURLConnection) new URL(url).openConnection();
+            HttpURLConnection connection = (HttpURLConnection) URI.create(url).toURL().openConnection();
             connection.setRequestProperty("User-Agent", "Mozilla/5.0");
-            try (BufferedReader reader = new BufferedReader(new InputStreamReader(connection.getInputStream()))) {
+            try (BufferedReader reader = new BufferedReader(
+                    new InputStreamReader(connection.getInputStream(), StandardCharsets.UTF_8))) {
                 List<Bar> bars = reader.lines()
                         .skip(1)
                         .map(line -> parseCsvLine(instrument, line))


### PR DESCRIPTION
## Summary
- avoid deprecated `URL(String)` in FT CSV fallback
- specify UTF-8 charset when reading CSV stream

## Testing
- `javac -cp $CP -sourcepath src/main/java:/tmp/stubs -d /tmp/out -Xlint:deprecation src/main/java/com/leonarduk/finance/stockfeed/feed/ft/FTTimeSeriesPage.java /tmp/stubs/com/leonarduk/finance/stockfeed/Instrument.java /tmp/stubs/org/ta4j/core/Bar.java /tmp/stubs/com/leonarduk/finance/stockfeed/feed/ExtendedHistoricalQuote.java`


------
https://chatgpt.com/codex/tasks/task_e_68a1b7ce356883279f49aaefde7eb8a5