### PR TITLE
Update enforcer plugin

### DIFF
--- a/timeseries-spring-boot-server/pom.xml
+++ b/timeseries-spring-boot-server/pom.xml
@@ -173,12 +173,12 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-enforcer-plugin</artifactId>
-                <version>3.5.0</version>
+                <version>3.6.0</version>
                 <dependencies>
                     <dependency>
                         <groupId>org.apache.maven.enforcer</groupId>
                         <artifactId>enforcer-rules</artifactId>
-                        <version>3.5.0</version>
+                        <version>3.6.0</version>
                     </dependency>
                 </dependencies>
                 <executions>


### PR DESCRIPTION
## Summary
- upgrade maven-enforcer-plugin to 3.6.0 with matching enforcer-rules dependency

## Testing
- `mvn clean install` *(fails: Non-resolvable parent POM for com.leonarduk:timeseries-spring-boot-server:0.1.1)*

------
https://chatgpt.com/codex/tasks/task_e_68a1b7cbf6288327b87a16f5eafcc49a