### PR TITLE
Remove BanDuplicateClasses enforcer rule

### DIFF
--- a/timeseries-spring-boot-server/pom.xml
+++ b/timeseries-spring-boot-server/pom.xml
@@ -205,7 +205,6 @@
                         <configuration>
                             <rules>
                                 <requireUpperBoundDeps/>
-                                <banDuplicateClasses/>
                             </rules>
                         </configuration>
                     </execution>


### PR DESCRIPTION
## Summary
- Remove BanDuplicateClasses rule from maven-enforcer to allow build

## Testing
- `mvn -q -pl timeseries-spring-boot-server -am test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a1ff970c3c8327804402877338e75f