### PR TITLE
Add pytest dependency for tests

### DIFF
--- a/timeseries-python/requirements.txt
+++ b/timeseries-python/requirements.txt
@@ -24,3 +24,4 @@ anyio~=4.9.0
 curl_cffi~=0.10.0
 openai>=1.0.0
 Flask~=3.0.3
+pytest~=8.4.1


### PR DESCRIPTION
## Summary
- include pytest in timeseries-python requirements so test runner is available

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a20e2e20d883278c51e861e4d7964c