### PR TITLE
chore: update run configurations for portability

### DIFF
--- a/.run/Timeseries Server.run.xml
+++ b/.run/Timeseries Server.run.xml
@@ -1,11 +1,11 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Timeseries Server" type="Application" factoryName="Application">
-    <option name="ALTERNATIVE_JRE_PATH" value="openjdk-24" />
+    <option name="ALTERNATIVE_JRE_PATH" value="openjdk-21" />
     <option name="ALTERNATIVE_JRE_PATH_ENABLED" value="true" />
     <option name="INCLUDE_PROVIDED_SCOPE" value="true" />
     <option name="MAIN_CLASS_NAME" value="com.leonarduk.finance.springboot.App" />
     <module name="timeseries-spring-boot-server" />
-    <option name="VM_PARAMETERS" value="-Dfilestore.path=&quot;C:\\Users\\steph\\workspaces\\luk\\data\\timeseries&quot; " />
+    <option name="VM_PARAMETERS" value="-Dfilestore.path=$PROJECT_DIR$/timeseries-stockfeed/src/main/resources/data" />
     <extension name="coverage">
       <pattern>
         <option name="PATTERN" value="com.leonarduk.finance.springboot.*" />

--- a/timeseries-python/.run/Finnhub - instrument_create .run.xml
+++ b/timeseries-python/.run/Finnhub - instrument_create .run.xml
@@ -6,7 +6,6 @@
     <option name="PARENT_ENVS" value="true" />
     <envs>
       <env name="PYTHONUNBUFFERED" value="1" />
-      <env name="FINNHUB_API_KEY" value="btjtt2v48v6vivbnrcf0" />
     </envs>
     <option name="SDK_HOME" value="" />
     <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$/integrations/finnhub" />


### PR DESCRIPTION
## Summary
- align Timeseries Server run configuration with JDK 21 and use a relative filestore path
- remove hard-coded Finnhub API key from Python run configuration

## Testing
- `pre-commit run --files .run/'Timeseries Server.run.xml' timeseries-python/.run/'Finnhub - instrument_create .run.xml'`
- `mvn -q -pl timeseries-stockfeed test` *(fails: PluginResolutionException - Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a22f82b06883279c73714edcfa65c2