### PR TITLE
Bump Flask to 3.1.3 to fix CVE-2026-27205

### DIFF
--- a/timeseries-python/requirements.txt
+++ b/timeseries-python/requirements.txt
@@ -23,4 +23,4 @@ python-dateutil~=2.9.0.post0
 anyio~=4.9.0
 curl_cffi~=0.10.0
 openai>=1.0.0
-Flask~=3.0.3
+Flask~=3.1.3


### PR DESCRIPTION
### Motivation
- Address the dependency security vulnerability CVE-2026-27205 reported for `Flask~=3.0.3` in `timeseries-python/requirements.txt` by upgrading to a patched release.

Closes #681 

### Description
- Updated `timeseries-python/requirements.txt` to change `Flask~=3.0.3` to `Flask~=3.1.3` so the project uses the release that contains the fix.

### Testing
- Ran `python -m compileall timeseries-python` to verify the Python package modules compile successfully (succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cda7832dc483278573fdad81453dfa)