### PR TITLE
Bump torch minimum version to 2.10.0

### DIFF
--- a/timeseries-python/requirements.txt
+++ b/timeseries-python/requirements.txt
@@ -2,7 +2,7 @@ yfinance~=0.2.58
 pandas~=2.2.3
 PyPortfolioOpt
 
-torch>=2.0.0
+torch>=2.10.0
 transformers>=4.30.0
 praw~=7.8.1
 textblob


### PR DESCRIPTION
### Motivation
- Raise the minimum PyTorch version to mitigate the security/compatibility concern referenced in issue Closes #662.

### Description
- Updated `timeseries-python/requirements.txt` to change the PyTorch floor from `torch>=2.0.0` to `torch>=2.10.0`.

### Testing
- Ran `python -m py_compile timeseries-python/analysis/sentiment/run_torch.py`, which completed without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cda79a7d508327a4adf95841de7467)