### PR TITLE
Upgrade vulnerable dependencies in timeseries-stockfeed (fixes #302)

### DIFF
--- a/timeseries-stockfeed/pom.xml
+++ b/timeseries-stockfeed/pom.xml
@@ -16,17 +16,17 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-text</artifactId>
-            <version>1.11.0</version>
+            <version>1.14.0</version>
         </dependency>
         <dependency>
             <groupId>org.seleniumhq.selenium</groupId>
             <artifactId>selenium-api</artifactId>
-            <version>4.14.0</version>
+            <version>${org.seleniumhq.selenium.version}</version>
         </dependency>
         <dependency>
             <groupId>org.seleniumhq.selenium</groupId>
             <artifactId>selenium-support</artifactId>
-            <version>4.14.0</version>
+            <version>${org.seleniumhq.selenium.version}</version>
         </dependency>
         <dependency>
             <groupId>org.ta4j</groupId>


### PR DESCRIPTION
### Motivation
- Address security/vulnerability concerns reported in issue Closes #302 by removing pinned older dependency versions in the `timeseries-stockfeed` module. 
- Ensure the module follows centrally managed versions to avoid accidentally pinning an out-of-date Selenium release. 
- Reduce exposure from an older `commons-text` release by upgrading to a newer, patched version.

### Description
- Updated `timeseries-stockfeed/pom.xml` to bump `org.apache.commons:commons-text` from `1.11.0` to `1.14.0`.
- Replaced hardcoded Selenium versions (`4.14.0`) with the shared `${org.seleniumhq.selenium.version}` property for `selenium-api` and `selenium-support` so the module inherits the parent-managed Selenium version.
- No other source code changes were made; the change is limited to the dependency declarations in `timeseries-stockfeed/pom.xml`.

### Testing
- Ran `mvn -pl timeseries-stockfeed -DskipTests validate` which completed successfully. 
- Attempted `mvn -pl timeseries-stockfeed -DskipTests dependency:tree -Dincludes=org.seleniumhq.selenium,net.sourceforge.htmlunit,io.netty,org.eclipse.jetty,org.apache.commons:commons-lang3` which failed due to an unresolved external artifact (`org.patriques:alphavantage4j:1.5.0`) in the environment, not due to the pom changes. 
- No unit or integration tests were run as part of this change beyond the module validation step.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ceb329d22c83279dcad47882d685ee)